### PR TITLE
Allow filter_user_has_cap() function to take only 3 arguments

### DIFF
--- a/user-switching.php
+++ b/user-switching.php
@@ -816,7 +816,7 @@ class user_switching {
 	 *     @type int       $1 Concerned user ID.
 	 *     @type mixed  ...$2 Optional second and further parameters.
 	 * }
-	 * @param WP_User  $user          Concerned user object.
+	 * @param WP_User  $user          Optional. Concerned user object.
 	 * @return bool[] Concerned user's capabilities.
 	 */
 	public function filter_user_has_cap( array $user_caps, array $required_caps, array $args, WP_User $user = null ) {

--- a/user-switching.php
+++ b/user-switching.php
@@ -819,7 +819,7 @@ class user_switching {
 	 * @param WP_User  $user          Concerned user object.
 	 * @return bool[] Concerned user's capabilities.
 	 */
-	public function filter_user_has_cap( array $user_caps, array $required_caps, array $args, WP_User $user ) {
+	public function filter_user_has_cap( array $user_caps, array $required_caps, array $args, WP_User $user = null ) {
 		if ( 'switch_to_user' === $args[0] ) {
 			$user_caps['switch_to_user'] = ( user_can( $user->ID, 'edit_user', $args[2] ) && ( $args[2] !== $user->ID ) );
 		} elseif ( 'switch_off' === $args[0] ) {


### PR DESCRIPTION
It appears there are some plugins that call the 'user_has_cap' filter with only 3 arguments, which causes a crash.

In my specific case it was the 'Revisionary' plugin that was doing this, but searching through this sites plugins installed it appears that the same code is in BuddyPress (though potentially dead code?)

```
wp-includes/class-wp-user.php:		$capabilities = apply_filters( 'user_has_cap', $this->allcaps, $caps, $args, $this );
wp-content/plugins/revisionary/lib/agapetry_wp_core_lib.php:		$capabilities = apply_filters('user_has_cap', $user->allcaps, $reqd_caps, $_args);
wp-content/plugins/revisionary/lib/agapetry_wp_core_lib.php:					$capabilities = apply_filters('user_has_cap', $user->allcaps, array($alternate_cap_name), $_args);
wp-content/plugins/buddypress/bp-forums/bbpress/bb-includes/backpress/class.bp-user.php:		$capabilities = apply_filters( 'user_has_cap', $this->allcaps, $caps, $args );
```