### PR TITLE
Add support for session retention and re-use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"johnpbloch/wordpress": ">=4.9.0@stable",
 		"phpunit/phpunit": "^5",
 		"wimg/php-compatibility": "^8",
-		"wp-coding-standards/wpcs": "^1"
+		"wp-coding-standards/wpcs": "1.0"
 	},
     "extra": {
         "wordpress-install-dir": "vendor/wordpress"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,7 @@
 <ruleset name="User Switching">
 
 	<config name="installed_paths" value="../../wp-coding-standards/wpcs,../../wimg/php-compatibility" />
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.3-"/>
 
 	<exclude-pattern>*/features/*</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ This plugin allows you to quickly swap between user accounts in WordPress at the
  * Switch back: Instantly switch back to your originating account.
  * Switch off: Log out of your account but retain the ability to instantly switch back in again.
  * It's completely secure (see the *Security* section below).
- * Compatible with WordPress, WordPress Multisite, BuddyPress and bbPress.
+ * Compatible with WordPress, WordPress Multisite, BuddyPress, and bbPress.
 
 ### Security ###
 
@@ -32,6 +32,7 @@ This plugin allows you to quickly swap between user accounts in WordPress at the
  * Passwords are not (and cannot be) revealed.
  * Uses the cookie authentication system in WordPress when remembering the account(s) you've switched from and when switching back.
  * Implements the nonce security system in WordPress, meaning only those who intend to switch users can switch.
+ * Full support for user session validation where appropriate.
  * Full support for administration over SSL (if applicable).
 
 ### Usage ###

--- a/readme.md
+++ b/readme.md
@@ -93,10 +93,52 @@ Yes, there's a third party add-on plugin for this: [Admin Bar User Switching](ht
 
 ### Are any plugin actions called when a user switches account? ###
 
-Yes. When a user switches to another account, the `switch_to_user` hook is called with the new and old user IDs passed as parameters.
+Yes. When a user switches to another account, the `switch_to_user` hook is called:
 
-When a user switches back to their original account, the `switch_back_user` hook is called with the new (original) and old user IDs passed as parameters. Note that the old user ID can be boolean false if the user is switching back after they've been switched off.
+```php
+/**
+ * Fires when a user switches to another user account.
+ *
+ * @since 0.6.0
+ * @since 1.4.0 The `$new_token` and `$old_token` parameters were added.
+ *
+ * @param int    $user_id     The ID of the user being switched to.
+ * @param int    $old_user_id The ID of the user being switched from.
+ * @param string $new_token   The token of the session of the user being switched to. Can be an empty string
+ *                            or a token for a session that may or may not still be valid.
+ * @param string $old_token   The token of the session of the user being switched from.
+ */
+do_action( 'switch_to_user', $user_id, $old_user_id, $new_token, $old_token );
+```
 
-When a user switches off, the `switch_off_user` hook is called with the old user ID as a parameter.
+When a user switches back to their originating account, the `switch_back_user` hook is called:
 
-See the plugin source code for complete hook documentation.
+```php
+/**
+ * Fires when a user switches back to their originating account.
+ *
+ * @since 0.6.0
+ * @since 1.4.0 The `$new_token` and `$old_token` parameters were added.
+ *
+ * @param int       $user_id     The ID of the user being switched back to.
+ * @param int|false $old_user_id The ID of the user being switched from, or false if the user is switching back
+ *                               after having been switched off.
+ * @param string    $new_token   The token of the session of the user being switched to. Can be an empty string
+ *                               or a token for a session that may or may not still be valid.
+ * @param string    $old_token   The token of the session of the user being switched from.
+ */
+```
+
+When a user switches off, the `switch_off_user` hook is called:
+
+```php
+/**
+ * Fires when a user switches off.
+ *
+ * @since 0.6.0
+ * @since 1.4.0 The `$old_token` parameter was added.
+ *
+ * @param int    $old_user_id The ID of the user switching off.
+ * @param string $old_token   The token of the session of the user switching off.
+ */
+```

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,11 @@ See the [FAQ](https://wordpress.org/plugins/user-switching/faq/) for information
 
 ### Privacy Statement ###
 
-User Switching makes use of browser cookies in order to allow users to switch to another account. Its cookies operate using the same mechanism as the authentication cookies in WordPress core, therefore they contain the user's `user_login` field in plain text which should be treated as potentially personally identifiable information. The name of the cookies are `wordpress_user_sw_{hash}`, `wordpress_user_sw_secure_{hash}`, and `wordpress_user_sw_olduser_{hash}`, where `{hash}` is an identifier unique to the installation of WordPress.
+User Switching makes use of browser cookies in order to allow users to switch to another account. Its cookies operate using the same mechanism as the authentication cookies in WordPress core, therefore their values contain the user's `user_login` field in plain text which should be treated as potentially personally identifiable information. The names of the cookies are:
+
+* `wordpress_user_sw_{COOKIEHASH}`
+* `wordpress_user_sw_secure_{COOKIEHASH}`
+* `wordpress_user_sw_olduser_{COOKIEHASH}`
 
 User Switching does not send data to any third party, nor does it include any third party resources, nor will it ever do so.
 

--- a/tests/test-auth.php
+++ b/tests/test-auth.php
@@ -9,23 +9,31 @@ class User_Switching_Test_Auth extends User_Switching_Test {
 		$expiry = time() + 172800;
 
 		// A valid authentication cookie should pass authentication:
-		$auth_cookie = wp_generate_auth_cookie( $editor->ID, $expiry, 'auth' );
+		$auth_cookie = (object) array(
+			'cookie' => wp_generate_auth_cookie( $editor->ID, $expiry, 'auth' ),
+		);
 		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $auth_cookie ) );
 		$this->assertTrue( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
 
 		// An expired but otherwise valid authentication cookie should not pass authentication:
-		$auth_cookie = wp_generate_auth_cookie( $editor->ID, time() - 1000, 'auth' );
+		$auth_cookie = (object) array(
+			'cookie' => wp_generate_auth_cookie( $editor->ID, time() - 1000, 'auth' ),
+		);
 		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $auth_cookie ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
 
 		// A valid authentication cookie with the incorrect scheme should not pass authentication:
-		$logged_in_cookie = wp_generate_auth_cookie( $editor->ID, $expiry, 'logged_in' );
+		$logged_in_cookie = (object) array(
+			'cookie' => wp_generate_auth_cookie( $editor->ID, $expiry, 'logged_in' ),
+		);
 		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $logged_in_cookie ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
-		$logged_in_cookie = wp_generate_auth_cookie( $editor->ID, $expiry, 'secure_auth' );
+		$logged_in_cookie = (object) array(
+			'cookie' => wp_generate_auth_cookie( $editor->ID, $expiry, 'secure_auth' ),
+		);
 		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $logged_in_cookie ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
@@ -36,7 +44,9 @@ class User_Switching_Test_Auth extends User_Switching_Test {
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
 
 		// A non-JSON-encoded cookie should not pass authentication and not trigger any PHP errors:
-		$auth_cookie = wp_generate_auth_cookie( $editor->ID, $expiry, 'auth' );
+		$auth_cookie = (object) array(
+			'cookie' => wp_generate_auth_cookie( $editor->ID, $expiry, 'auth' ),
+		);
 		$_COOKIE[ USER_SWITCHING_COOKIE ] = $auth_cookie;
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );

--- a/tests/test-auth.php
+++ b/tests/test-auth.php
@@ -51,6 +51,12 @@ class User_Switching_Test_Auth extends User_Switching_Test {
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
 
+		// The old format cookie (a string instead of the cookie and token object) should not pass authentication:
+		$auth_cookie = wp_generate_auth_cookie( $editor->ID, $expiry, 'auth' );
+		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $auth_cookie ) );
+		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
+		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
+
 		// No cookie should not pass authentication and not trigger any PHP errors:
 		unset( $_COOKIE[ USER_SWITCHING_COOKIE ] );
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );

--- a/tests/test-auth.php
+++ b/tests/test-auth.php
@@ -9,31 +9,23 @@ class User_Switching_Test_Auth extends User_Switching_Test {
 		$expiry = time() + 172800;
 
 		// A valid authentication cookie should pass authentication:
-		$auth_cookie = (object) array(
-			'cookie' => wp_generate_auth_cookie( $editor->ID, $expiry, 'auth' ),
-		);
+		$auth_cookie = wp_generate_auth_cookie( $editor->ID, $expiry, 'auth' );
 		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $auth_cookie ) );
 		$this->assertTrue( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
 
 		// An expired but otherwise valid authentication cookie should not pass authentication:
-		$auth_cookie = (object) array(
-			'cookie' => wp_generate_auth_cookie( $editor->ID, time() - 1000, 'auth' ),
-		);
+		$auth_cookie = wp_generate_auth_cookie( $editor->ID, time() - 1000, 'auth' );
 		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $auth_cookie ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
 
 		// A valid authentication cookie with the incorrect scheme should not pass authentication:
-		$logged_in_cookie = (object) array(
-			'cookie' => wp_generate_auth_cookie( $editor->ID, $expiry, 'logged_in' ),
-		);
+		$logged_in_cookie = wp_generate_auth_cookie( $editor->ID, $expiry, 'logged_in' );
 		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $logged_in_cookie ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
-		$logged_in_cookie = (object) array(
-			'cookie' => wp_generate_auth_cookie( $editor->ID, $expiry, 'secure_auth' ),
-		);
+		$logged_in_cookie = wp_generate_auth_cookie( $editor->ID, $expiry, 'secure_auth' );
 		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $logged_in_cookie ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
@@ -44,16 +36,8 @@ class User_Switching_Test_Auth extends User_Switching_Test {
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
 
 		// A non-JSON-encoded cookie should not pass authentication and not trigger any PHP errors:
-		$auth_cookie = (object) array(
-			'cookie' => wp_generate_auth_cookie( $editor->ID, $expiry, 'auth' ),
-		);
-		$_COOKIE[ USER_SWITCHING_COOKIE ] = $auth_cookie;
-		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
-		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
-
-		// The old format cookie (a string instead of the cookie and token object) should not pass authentication:
 		$auth_cookie = wp_generate_auth_cookie( $editor->ID, $expiry, 'auth' );
-		$_COOKIE[ USER_SWITCHING_COOKIE ] = json_encode( array( $auth_cookie ) );
+		$_COOKIE[ USER_SWITCHING_COOKIE ] = $auth_cookie;
 		$this->assertFalse( user_switching::authenticate_old_user( $editor ) );
 		$this->assertFalse( user_switching::authenticate_old_user( $admin ) );
 

--- a/tests/test-sessions.php
+++ b/tests/test-sessions.php
@@ -82,4 +82,36 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 		$this->assertSame( $admin_token, $parts['token'] );
 	}
 
+	public function testPreviousSessionForUserIsReusedWhenSwitchingBack() {
+		if ( is_multisite() ) {
+			$admin = self::$testers['super'];
+		} else {
+			$admin = self::$testers['admin'];
+		}
+
+		// Set up the admin session manager with a session
+		$admin_manager = WP_Session_Tokens::get_instance( $admin->ID );
+		$admin_token   = $admin_manager->create( time() + DAY_IN_SECONDS );
+		$admin_before  = $admin_manager->get_all();
+
+		// Set up the admin user state
+		wp_set_current_user( $admin->ID );
+		wp_set_auth_cookie( $admin->ID, false, '', $admin_token );
+
+		// Verify the initial state
+		$this->assertCount( 1, $admin_before );
+
+		// Switch user
+		$user = $this->switch_to_user( self::$users['author']->ID );
+
+		// Verify no new sessions were created for the old user
+		$this->assertCount( 1, $admin_manager->get_all() );
+
+		// Switch back
+		$user = $this->switch_to_user( $admin->ID, false, false );
+
+		// Verify no new sessions were created for the original user
+		$this->assertCount( 1, $admin_manager->get_all() );
+	}
+
 }

--- a/tests/test-sessions.php
+++ b/tests/test-sessions.php
@@ -22,10 +22,6 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 		wp_set_current_user( $admin->ID );
 		wp_set_auth_cookie( $admin->ID, false, '', $admin_token );
 
-		// Sanity checks
-		$this->assertNotEmpty( $admin_token );
-		$this->assertNotEmpty( wp_get_session_token() );
-
 		// Verify the initial state
 		$this->assertCount( 1, $admin_before );
 		$this->assertCount( 0, $author_before );
@@ -38,12 +34,6 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 
 		// Verify only one new session was created for the new user
 		$this->assertCount( 1, $author_manager->get_all() );
-
-		$cookie = user_switching_get_auth_cookie();
-		$parts  = wp_parse_auth_cookie( end( $cookie ) );
-
-		// Verify the stored session token matches
-		$this->assertSame( $admin_token, $parts['token'] );
 	}
 
 	public function testExtraSessionsAreNotCreatedForUserWhenSwitchingOff() {
@@ -62,10 +52,6 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 		wp_set_current_user( $admin->ID );
 		wp_set_auth_cookie( $admin->ID, false, '', $admin_token );
 
-		// Sanity checks
-		$this->assertNotEmpty( $admin_token );
-		$this->assertNotEmpty( wp_get_session_token() );
-
 		// Verify the initial state
 		$this->assertCount( 1, $admin_before );
 
@@ -74,12 +60,6 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 
 		// Verify no new sessions were created for the old user
 		$this->assertCount( 1, $admin_manager->get_all() );
-
-		$cookie = user_switching_get_auth_cookie();
-		$parts  = wp_parse_auth_cookie( end( $cookie ) );
-
-		// Verify the stored session token matches
-		$this->assertSame( $admin_token, $parts['token'] );
 	}
 
 	public function testPreviousSessionForUserIsReusedWhenSwitchingBack() {
@@ -93,6 +73,9 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 		$admin_manager = WP_Session_Tokens::get_instance( $admin->ID );
 		$admin_token   = $admin_manager->create( time() + DAY_IN_SECONDS );
 		$admin_before  = $admin_manager->get_all();
+
+		// Set up the author session manager, but with no session
+		$author_manager = WP_Session_Tokens::get_instance( self::$users['author']->ID );
 
 		// Set up the admin user state
 		wp_set_current_user( $admin->ID );
@@ -112,6 +95,9 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 
 		// Verify no new sessions were created for the original user
 		$this->assertCount( 1, $admin_manager->get_all() );
+
+		// Verify the session for the switched to user was destroyed
+		$this->assertCount( 0, $author_manager->get_all() );
 	}
 
 	public function testExpiredSessionPreventsUserFromSwitchingBack() {
@@ -152,7 +138,7 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 		$existing['expiration'] = time() - HOUR_IN_SECONDS;
 		$admin_manager->update( $admin_token, $existing );
 
-		// Sanity checks
+		// Verify the old session has been invalidated
 		$this->assertNull( $admin_manager->get( $admin_token ) );
 		$this->assertFalse( user_switching::get_old_user() );
 

--- a/tests/test-sessions.php
+++ b/tests/test-sessions.php
@@ -2,34 +2,42 @@
 
 class User_Switching_Test_Sessions extends User_Switching_Test {
 
-	public function testExtraSessionsAreNotCreatedForOldUserWhenSwitching() {
+	public function testExtraSessionsAreNotCreatedForUsersWhenSwitching() {
 		if ( is_multisite() ) {
 			$admin = self::$testers['super'];
 		} else {
 			$admin = self::$testers['admin'];
 		}
 
-		// Set up the session
-		$manager = WP_Session_Tokens::get_instance( $admin->ID );
-		$token   = $manager->create( time() + DAY_IN_SECONDS );
-		$before  = $manager->get_all();
+		// Set up the admin session manager with a session
+		$admin_manager = WP_Session_Tokens::get_instance( $admin->ID );
+		$admin_token   = $admin_manager->create( time() + DAY_IN_SECONDS );
+		$admin_before  = $admin_manager->get_all();
 
-		// Set up the user state
+		// Set up the author session manager, but with no session
+		$author_manager = WP_Session_Tokens::get_instance( self::$users['author']->ID );
+		$author_before  = $author_manager->get_all();
+
+		// Set up the admin user state
 		wp_set_current_user( $admin->ID );
-		wp_set_auth_cookie( $admin->ID, false, '', $token );
+		wp_set_auth_cookie( $admin->ID, false, '', $admin_token );
 
 		// Sanity checks
-		$this->assertNotEmpty( $token );
+		$this->assertNotEmpty( $admin_token );
 		$this->assertNotEmpty( wp_get_session_token() );
 
-		// Start with a base session
-		$this->assertCount( 1, $before );
+		// Verify the initial state
+		$this->assertCount( 1, $admin_before );
+		$this->assertCount( 0, $author_before );
 
 		// Switch user
 		$user = $this->switch_to_user( self::$users['author']->ID );
 
 		// Verify no new sessions were created for the old user
-		$this->assertCount( 1, $manager->get_all() );
+		$this->assertCount( 1, $admin_manager->get_all() );
+
+		// Verify only one new session was created for the new user
+		$this->assertCount( 1, $author_manager->get_all() );
 	}
 
 }

--- a/tests/test-sessions.php
+++ b/tests/test-sessions.php
@@ -1,0 +1,35 @@
+<?php
+
+class User_Switching_Test_Sessions extends User_Switching_Test {
+
+	public function testExtraSessionsAreNotCreatedForOldUserWhenSwitching() {
+		if ( is_multisite() ) {
+			$admin = self::$testers['super'];
+		} else {
+			$admin = self::$testers['admin'];
+		}
+
+		// Set up the session
+		$manager = WP_Session_Tokens::get_instance( $admin->ID );
+		$token   = $manager->create( time() + DAY_IN_SECONDS );
+		$before  = $manager->get_all();
+
+		// Set up the user state
+		wp_set_current_user( $admin->ID );
+		wp_set_auth_cookie( $admin->ID, false, '', $token );
+
+		// Sanity checks
+		$this->assertNotEmpty( $token );
+		$this->assertNotEmpty( wp_get_session_token() );
+
+		// Start with a base session
+		$this->assertCount( 1, $before );
+
+		// Switch user
+		$user = $this->switch_to_user( self::$users['author']->ID );
+
+		// Verify no new sessions were created for the old user
+		$this->assertCount( 1, $manager->get_all() );
+	}
+
+}

--- a/tests/test-sessions.php
+++ b/tests/test-sessions.php
@@ -38,6 +38,12 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 
 		// Verify only one new session was created for the new user
 		$this->assertCount( 1, $author_manager->get_all() );
+
+		$cookie = user_switching_get_auth_cookie();
+		$parts  = wp_parse_auth_cookie( end( $cookie ) );
+
+		// Verify the stored session token matches
+		$this->assertSame( $admin_token, $parts['token'] );
 	}
 
 }

--- a/tests/test-sessions.php
+++ b/tests/test-sessions.php
@@ -46,4 +46,40 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 		$this->assertSame( $admin_token, $parts['token'] );
 	}
 
+	public function testExtraSessionsAreNotCreatedForUserWhenSwitchingOff() {
+		if ( is_multisite() ) {
+			$admin = self::$testers['super'];
+		} else {
+			$admin = self::$testers['admin'];
+		}
+
+		// Set up the admin session manager with a session
+		$admin_manager = WP_Session_Tokens::get_instance( $admin->ID );
+		$admin_token   = $admin_manager->create( time() + DAY_IN_SECONDS );
+		$admin_before  = $admin_manager->get_all();
+
+		// Set up the admin user state
+		wp_set_current_user( $admin->ID );
+		wp_set_auth_cookie( $admin->ID, false, '', $admin_token );
+
+		// Sanity checks
+		$this->assertNotEmpty( $admin_token );
+		$this->assertNotEmpty( wp_get_session_token() );
+
+		// Verify the initial state
+		$this->assertCount( 1, $admin_before );
+
+		// Switch off
+		$switched = $this->switch_off_user();
+
+		// Verify no new sessions were created for the old user
+		$this->assertCount( 1, $admin_manager->get_all() );
+
+		$cookie = user_switching_get_auth_cookie();
+		$parts  = wp_parse_auth_cookie( end( $cookie ) );
+
+		// Verify the stored session token matches
+		$this->assertSame( $admin_token, $parts['token'] );
+	}
+
 }

--- a/tests/test-sessions.php
+++ b/tests/test-sessions.php
@@ -114,4 +114,45 @@ class User_Switching_Test_Sessions extends User_Switching_Test {
 		$this->assertCount( 1, $admin_manager->get_all() );
 	}
 
+	public function testExpiredSessionPreventsUserFromSwitchingBack() {
+		if ( is_multisite() ) {
+			$admin = self::$testers['super'];
+		} else {
+			$admin = self::$testers['admin'];
+		}
+
+		// Set up the admin session manager with a session
+		$admin_manager = WP_Session_Tokens::get_instance( $admin->ID );
+		$admin_token   = $admin_manager->create( time() + DAY_IN_SECONDS );
+		$admin_before  = $admin_manager->get_all();
+
+		// Set up the admin user state
+		wp_set_current_user( $admin->ID );
+		wp_set_auth_cookie( $admin->ID, false, '', $admin_token );
+
+		// Verify the initial state
+		$this->assertCount( 1, $admin_before );
+
+		// Switch user
+		$user = $this->switch_to_user( self::$users['author']->ID );
+
+		// Verify no new sessions were created for the old user
+		$this->assertCount( 1, $admin_manager->get_all() );
+
+		// Invalidate the session that the user switched from, to mock its expiry while switched
+		$existing = $admin_manager->get( $admin_token );
+		$existing['expiration'] = time() - HOUR_IN_SECONDS;
+		$admin_manager->update( $admin_token, $existing );
+
+		// Sanity checks
+		$this->assertNull( $admin_manager->get( $admin_token ) );
+		$this->assertFalse( user_switching::get_old_user() );
+
+		// Attempt to switch back
+		$user = $this->switch_to_user( $admin->ID, false, false );
+
+		// Verify no new session was created for the original user
+		$this->assertCount( 0, $admin_manager->get_all() );
+	}
+
 }

--- a/tests/user-switching-test.php
+++ b/tests/user-switching-test.php
@@ -36,59 +36,15 @@ abstract class User_Switching_Test extends WP_UnitTestCase {
 			grant_super_admin( self::$testers['super']->ID );
 		}
 
+		add_filter( 'send_auth_cookies', '__return_false' );
 	}
 
 	protected function switch_to_user( $user_id, $remember = false, $set_old_user = true ) {
-
-		// Verify the integrity of our wrapper methods
-		$target  = new ReflectionFunction( 'switch_to_user' );
-		$wrapper = new ReflectionMethod( __METHOD__ );
-		$this->assertSame( $wrapper->getNumberOfParameters(), $target->getNumberOfParameters() );
-
-		/*
-		 * `switch_to_user()` and the functions it subsequently calls will trigger "headers already sent" PHP errors, so
-		 * we need to mute them in order to avoid phpunit throwing an exception.
-		 */
-		$this->silence();
-		$user = switch_to_user( $user_id, $remember, $set_old_user );
-		$this->go_forth();
-
-		return $user;
-
+		return switch_to_user( $user_id, $remember, $set_old_user );
 	}
 
 	protected function switch_off_user() {
-
-		// Verify the integrity of our wrapper methods
-		$target  = new ReflectionFunction( 'switch_off_user' );
-		$wrapper = new ReflectionMethod( __METHOD__ );
-		$this->assertSame( $wrapper->getNumberOfParameters(), $target->getNumberOfParameters() );
-
-		/*
-		 * `switch_off_user()` and the functions it subsequently calls will trigger "headers already sent" PHP errors, so
-		 * we need to mute them in order to avoid phpunit throwing an exception.
-		 */
-		$this->silence();
-		$user = switch_off_user();
-		$this->go_forth();
-
-		return $user;
-
-	}
-
-	private function silence() {
-		$this->silence_warning = PHPUnit_Framework_Error_Warning::$enabled;
-		PHPUnit_Framework_Error_Warning::$enabled = false;
-		$this->silence_display = ini_get( 'display_errors' );
-		$this->silence_log = ini_get( 'error_log' );
-		ini_set( 'display_errors', 0 );
-		ini_set( 'error_log', '/dev/null' );
-	}
-
-	private function go_forth() {
-		PHPUnit_Framework_Error_Warning::$enabled = $this->silence_warning;
-		ini_set( 'display_errors', $this->silence_display );
-		ini_set( 'error_log', $this->silence_log );
+		return switch_off_user();
 	}
 
 }

--- a/tests/user-switching-test.php
+++ b/tests/user-switching-test.php
@@ -12,6 +12,8 @@ abstract class User_Switching_Test extends WP_UnitTestCase {
 	 */
 	protected static $testers = array();
 
+	protected $sessions = array();
+
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 
 		$roles = array(
@@ -61,6 +63,7 @@ abstract class User_Switching_Test extends WP_UnitTestCase {
 	public function action_set_auth_cookie( $cookie, $expire, $expiration, $user_id, $scheme, $token ) {
 		$_COOKIE[ SECURE_AUTH_COOKIE ] = $cookie;
 		$_COOKIE[ AUTH_COOKIE ]        = $cookie;
+		$this->sessions[ $user_id ]    = $token;
 	}
 
 	public function action_set_logged_in_cookie( $cookie, $expire, $expiration, $user_id, $scheme, $token ) {

--- a/tests/user-switching-test.php
+++ b/tests/user-switching-test.php
@@ -67,10 +67,8 @@ abstract class User_Switching_Test extends WP_UnitTestCase {
 	}
 
 	public function action_set_user_switching_cookie( $cookie, $expiration, $user_id, $scheme, $token ) {
-		$value = json_encode( $cookie );
-
-		$_COOKIE[ USER_SWITCHING_COOKIE ]        = $value;
-		$_COOKIE[ USER_SWITCHING_SECURE_COOKIE ] = $value;
+		$_COOKIE[ USER_SWITCHING_COOKIE ]        = $cookie;
+		$_COOKIE[ USER_SWITCHING_SECURE_COOKIE ] = $cookie;
 	}
 
 	public function action_set_olduser_cookie( $cookie, $expiration, $user_id, $scheme, $token ) {

--- a/tests/user-switching-test.php
+++ b/tests/user-switching-test.php
@@ -39,6 +39,50 @@ abstract class User_Switching_Test extends WP_UnitTestCase {
 		add_filter( 'send_auth_cookies', '__return_false' );
 	}
 
+	public function setUp() {
+		add_action( 'set_auth_cookie',           array( $this, 'action_set_auth_cookie' ), 10, 6 );
+		add_action( 'set_logged_in_cookie',      array( $this, 'action_set_logged_in_cookie' ), 10, 6 );
+		add_action( 'clear_auth_cookie',         array( $this, 'action_clear_auth_cookie' ) );
+
+		add_action( 'set_user_switching_cookie', array( $this, 'action_set_user_switching_cookie' ), 10, 5 );
+		add_action( 'set_olduser_cookie',        array( $this, 'action_set_olduser_cookie' ), 10, 5 );
+		add_action( 'clear_olduser_cookie',      array( $this, 'action_clear_olduser_cookie' ) );
+
+		parent::setUp();
+	}
+
+	public function action_set_auth_cookie( $cookie, $expire, $expiration, $user_id, $scheme, $token ) {
+		$_COOKIE[ SECURE_AUTH_COOKIE ] = $cookie;
+		$_COOKIE[ AUTH_COOKIE ]        = $cookie;
+	}
+
+	public function action_set_logged_in_cookie( $cookie, $expire, $expiration, $user_id, $scheme, $token ) {
+		$_COOKIE[ LOGGED_IN_COOKIE ] = $cookie;
+	}
+
+	public function action_clear_auth_cookie() {
+		unset( $_COOKIE[ LOGGED_IN_COOKIE ] );
+		unset( $_COOKIE[ SECURE_AUTH_COOKIE ] );
+		unset( $_COOKIE[ AUTH_COOKIE ] );
+	}
+
+	public function action_set_user_switching_cookie( $cookie, $expiration, $user_id, $scheme, $token ) {
+		$value = json_encode( $cookie );
+
+		$_COOKIE[ USER_SWITCHING_COOKIE ]        = $value;
+		$_COOKIE[ USER_SWITCHING_SECURE_COOKIE ] = $value;
+	}
+
+	public function action_set_olduser_cookie( $cookie, $expiration, $user_id, $scheme, $token ) {
+		$_COOKIE[ USER_SWITCHING_OLDUSER_COOKIE ] = $cookie;
+	}
+
+	public function action_clear_olduser_cookie() {
+		unset( $_COOKIE[ USER_SWITCHING_COOKIE ] );
+		unset( $_COOKIE[ USER_SWITCHING_SECURE_COOKIE ] );
+		unset( $_COOKIE[ USER_SWITCHING_OLDUSER_COOKIE ] );
+	}
+
 	protected function switch_to_user( $user_id, $remember = false, $set_old_user = true ) {
 		return switch_to_user( $user_id, $remember, $set_old_user );
 	}

--- a/tests/user-switching-test.php
+++ b/tests/user-switching-test.php
@@ -2,7 +2,14 @@
 
 abstract class User_Switching_Test extends WP_UnitTestCase {
 
-	protected static $users   = array();
+	/**
+	 * @var WP_User[]
+	 */
+	protected static $users = array();
+
+	/**
+	 * @var WP_User[]
+	 */
 	protected static $testers = array();
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {

--- a/user-switching.php
+++ b/user-switching.php
@@ -1073,6 +1073,12 @@ if ( ! function_exists( 'switch_to_user' ) ) {
 			do_action( 'switch_back_user', $user_id, $old_user_id, $new_token, $old_token );
 		}
 
+		if ( $old_token && $old_user_id && ! $set_old_user ) {
+			// When switching back, destroy the session for the old user
+			$manager = WP_Session_Tokens::get_instance( $old_user_id );
+			$manager->destroy( $old_token );
+		}
+
 		return $user;
 	}
 }

--- a/user-switching.php
+++ b/user-switching.php
@@ -1053,22 +1053,30 @@ if ( ! function_exists( 'switch_to_user' ) ) {
 			 * Fires when a user switches to another user account.
 			 *
 			 * @since 0.6.0
+			 * @since 1.4.0 The `$old_token` and `$new_token` parameters were added.
 			 *
-			 * @param int $user_id     The ID of the user being switched to.
-			 * @param int $old_user_id The ID of the user being switched from.
+			 * @param int    $user_id     The ID of the user being switched to.
+			 * @param int    $old_user_id The ID of the user being switched from.
+			 * @param string $old_token   The token of the session of the user being switched from.
+			 * @param string $new_token   The token of the session of the user being switched to. Can be an empty string
+			 *                            or a token for a session that may or may not still be valid.
 			 */
-			do_action( 'switch_to_user', $user_id, $old_user_id );
+			do_action( 'switch_to_user', $user_id, $old_user_id, $old_token, $new_token );
 		} else {
 			/**
 			 * Fires when a user switches back to their originating account.
 			 *
 			 * @since 0.6.0
+			 * @since 1.4.0 The `$old_token` and `$new_token` parameters were added.
 			 *
 			 * @param int       $user_id     The ID of the user being switched back to.
 			 * @param int|false $old_user_id The ID of the user being switched from, or false if the user is switching back
 			 *                               after having been switched off.
+			 * @param string    $old_token   The token of the session of the user being switched from.
+			 * @param string    $new_token   The token of the session of the user being switched to. Can be an empty string
+			 *                               or a token for a session that may or may not still be valid.
 			 */
-			do_action( 'switch_back_user', $user_id, $old_user_id );
+			do_action( 'switch_back_user', $user_id, $old_user_id, $old_token, $new_token );
 		}
 
 		return $user;
@@ -1099,10 +1107,12 @@ if ( ! function_exists( 'switch_off_user' ) ) {
 		 * Fires when a user switches off.
 		 *
 		 * @since 0.6.0
+		 * @since 1.4.0 The `$old_token` parameter was added.
 		 *
-		 * @param int $old_user_id The ID of the user switching off.
+		 * @param int    $old_user_id The ID of the user switching off.
+		 * @param string $old_token   The token of the session of the user switching off.
 		 */
-		do_action( 'switch_off_user', $old_user_id );
+		do_action( 'switch_off_user', $old_user_id, $old_token );
 
 		return true;
 	}

--- a/user-switching.php
+++ b/user-switching.php
@@ -1083,7 +1083,9 @@ if ( ! function_exists( 'switch_off_user' ) ) {
 			return false;
 		}
 
-		user_switching_set_olduser_cookie( $old_user_id );
+		$old_token = function_exists( 'wp_get_session_token' ) ? wp_get_session_token() : '';
+
+		user_switching_set_olduser_cookie( $old_user_id, false, $old_token );
 		wp_clear_auth_cookie();
 		wp_set_current_user( 0 );
 

--- a/user-switching.php
+++ b/user-switching.php
@@ -17,6 +17,7 @@
  * Text Domain: user-switching
  * Domain Path: /languages/
  * Network:     true
+ * Requires PHP: 5.3
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1038,9 +1039,26 @@ if ( ! function_exists( 'switch_to_user' ) ) {
 			user_switching_clear_olduser_cookie( false );
 		}
 
+		/**
+		 * Attaches the original user ID and session token to the new session when a user switches to another user.
+		 *
+		 * @param array $session Array of extra data.
+		 * @param int   $user_id User ID.
+		 * @return array Array of extra data.
+		 */
+		$session_filter = function( array $session, $user_id ) use ( $old_user_id, $old_token ) {
+			$session['switched_from_id']      = $old_user_id;
+			$session['switched_from_session'] = $old_token;
+			return $session;
+		};
+
+		add_filter( 'attach_session_information', $session_filter, 99, 2 );
+
 		wp_clear_auth_cookie();
 		wp_set_auth_cookie( $user_id, $remember, '', $new_token );
 		wp_set_current_user( $user_id );
+
+		remove_filter( 'attach_session_information', $session_filter, 99 );
 
 		if ( $set_old_user ) {
 			/**

--- a/user-switching.php
+++ b/user-switching.php
@@ -908,6 +908,11 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 			array_push( $auth_cookie, wp_generate_auth_cookie( $old_user_id, $expiration, $scheme ) );
 		}
 
+		/** This filter is documented in wp-includes/pluggable.php */
+		if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+			return;
+		}
+
 		setcookie( $auth_cookie_name, json_encode( $auth_cookie ), $expiration, SITECOOKIEPATH, COOKIE_DOMAIN, $secure_auth_cookie, true );
 		setcookie( USER_SWITCHING_OLDUSER_COOKIE, $olduser_cookie, $expiration, COOKIEPATH, COOKIE_DOMAIN, $secure_olduser_cookie, true );
 	}
@@ -925,6 +930,11 @@ if ( ! function_exists( 'user_switching_clear_olduser_cookie' ) ) {
 			array_pop( $auth_cookie );
 		}
 		if ( $clear_all || empty( $auth_cookie ) ) {
+			/** This filter is documented in wp-includes/pluggable.php */
+			if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+				return;
+			}
+
 			$expire = time() - 31536000;
 			setcookie( USER_SWITCHING_COOKIE,         ' ', $expire, SITECOOKIEPATH, COOKIE_DOMAIN );
 			setcookie( USER_SWITCHING_SECURE_COOKIE,  ' ', $expire, SITECOOKIEPATH, COOKIE_DOMAIN );

--- a/user-switching.php
+++ b/user-switching.php
@@ -908,6 +908,34 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 			array_push( $auth_cookie, wp_generate_auth_cookie( $old_user_id, $expiration, $scheme ) );
 		}
 
+		/**
+		 * Fires immediately before the User Switching authentication cookie is set.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param string[] $auth_cookie Array of authentication cookies.
+		 * @param int    $expiration  The time when the authentication cookie expires as a UNIX timestamp.
+		 *                            Default is 48 hours from now.
+		 * @param int    $old_user_id User ID.
+		 * @param string $scheme      Authentication scheme. Values include 'auth' or 'secure_auth'.
+		 * @param string $token       User's session token to use for the latest cookie.
+		 */
+		do_action( 'set_user_switching_cookie', $auth_cookie, $expiration, $old_user_id, $scheme, $token );
+
+		/**
+		 * Fires immediately before the User Switching old user cookie is set.
+		 *
+		 * @since 1.4.0
+		 *
+		 * @param string $olduser_cookie The old user cookie value.
+		 * @param int    $expiration     The time when the logged-in authentication cookie expires as a UNIX timestamp.
+		 *                               Default is 48 hours from now.
+		 * @param int    $old_user_id    User ID.
+		 * @param string $scheme         Authentication scheme. Default 'logged_in'.
+		 * @param string $token          User's session token to use for this cookie.
+		 */
+		do_action( 'set_olduser_cookie', $olduser_cookie, $expiration, $old_user_id, 'logged_in', $token );
+
 		/** This filter is documented in wp-includes/pluggable.php */
 		if ( ! apply_filters( 'send_auth_cookies', true ) ) {
 			return;
@@ -930,6 +958,14 @@ if ( ! function_exists( 'user_switching_clear_olduser_cookie' ) ) {
 			array_pop( $auth_cookie );
 		}
 		if ( $clear_all || empty( $auth_cookie ) ) {
+
+			/**
+			 * Fires just before the user switching cookies are cleared.
+			 *
+			 * @since 1.4.0
+			 */
+			do_action( 'clear_olduser_cookie' );
+
 			/** This filter is documented in wp-includes/pluggable.php */
 			if ( ! apply_filters( 'send_auth_cookies', true ) ) {
 				return;

--- a/user-switching.php
+++ b/user-switching.php
@@ -1047,30 +1047,30 @@ if ( ! function_exists( 'switch_to_user' ) ) {
 			 * Fires when a user switches to another user account.
 			 *
 			 * @since 0.6.0
-			 * @since 1.4.0 The `$old_token` and `$new_token` parameters were added.
+			 * @since 1.4.0 The `$new_token` and `$old_token` parameters were added.
 			 *
 			 * @param int    $user_id     The ID of the user being switched to.
 			 * @param int    $old_user_id The ID of the user being switched from.
-			 * @param string $old_token   The token of the session of the user being switched from.
 			 * @param string $new_token   The token of the session of the user being switched to. Can be an empty string
 			 *                            or a token for a session that may or may not still be valid.
+			 * @param string $old_token   The token of the session of the user being switched from.
 			 */
-			do_action( 'switch_to_user', $user_id, $old_user_id, $old_token, $new_token );
+			do_action( 'switch_to_user', $user_id, $old_user_id, $new_token, $old_token );
 		} else {
 			/**
 			 * Fires when a user switches back to their originating account.
 			 *
 			 * @since 0.6.0
-			 * @since 1.4.0 The `$old_token` and `$new_token` parameters were added.
+			 * @since 1.4.0 The `$new_token` and `$old_token` parameters were added.
 			 *
 			 * @param int       $user_id     The ID of the user being switched back to.
 			 * @param int|false $old_user_id The ID of the user being switched from, or false if the user is switching back
 			 *                               after having been switched off.
-			 * @param string    $old_token   The token of the session of the user being switched from.
 			 * @param string    $new_token   The token of the session of the user being switched to. Can be an empty string
 			 *                               or a token for a session that may or may not still be valid.
+			 * @param string    $old_token   The token of the session of the user being switched from.
 			 */
-			do_action( 'switch_back_user', $user_id, $old_user_id, $old_token, $new_token );
+			do_action( 'switch_back_user', $user_id, $old_user_id, $new_token, $old_token );
 		}
 
 		return $user;

--- a/user-switching.php
+++ b/user-switching.php
@@ -35,7 +35,7 @@
 class user_switching {
 
 	/**
-	 * The name used to identify the application for debugging purposes.
+	 * The name used to identify the application during a WordPress redirect.
 	 *
 	 * @var string
 	 */
@@ -89,7 +89,7 @@ class user_switching {
 	}
 
 	/**
-	 * Outputs the 'Switch To' link on the user editing screen if we have permission to switch to this user.
+	 * Outputs the 'Switch To' link on the user editing screen if the current user has permission to switch to them.
 	 *
 	 * @param WP_User $user User object for this screen.
 	 */
@@ -116,17 +116,7 @@ class user_switching {
 	 * @return bool Whether the current user is being 'remembered' or not.
 	 */
 	public static function remember() {
-		/**
-		 * Filter the duration of the authentication cookie expiration period.
-		 *
-		 * This matches the WordPress core filter in `wp_set_auth_cookie()`.
-		 *
-		 * @since 0.2.2
-		 *
-		 * @param int  $length   Duration of the expiration period in seconds.
-		 * @param int  $user_id  User ID.
-		 * @param bool $remember Whether to remember the user login. Default false.
-		 */
+		/** This filter is documented in wp-includes/pluggable.php */
 		$cookie_life = apply_filters( 'auth_cookie_expiration', 172800, get_current_user_id(), false );
 		$current     = wp_parse_auth_cookie( '', 'logged_in' );
 
@@ -282,30 +272,10 @@ class user_switching {
 		}
 
 		if ( ! $new_user ) {
-			/**
-			 * Filter the redirect URL when a user switches off.
-			 *
-			 * This matches the WordPress core filter in wp-login.php.
-			 *
-			 * @since 1.0.4
-			 *
-			 * @param string  $redirect_to           The redirect destination URL.
-			 * @param string  $requested_redirect_to The requested redirect destination URL passed as a parameter.
-			 * @param WP_User $old_user              The WP_User object for the user that's switching off.
-			 */
+			/** This filter is documented in wp-login.php */
 			$redirect_to = apply_filters( 'logout_redirect', $redirect_to, $requested_redirect_to, $old_user );
 		} else {
-			/**
-			 * Filter the redirect URL when a user switches to another user or switches back.
-			 *
-			 * This matches the WordPress core filter in wp-login.php.
-			 *
-			 * @since 0.8.7
-			 *
-			 * @param string  $redirect_to           The redirect destination URL.
-			 * @param string  $requested_redirect_to The requested redirect destination URL passed as a parameter.
-			 * @param WP_User $new_user              The WP_User object for the user that's being switched to.
-			 */
+			/** This filter is documented in wp-login.php */
 			$redirect_to = apply_filters( 'login_redirect', $redirect_to, $requested_redirect_to, $new_user );
 		}
 
@@ -417,7 +387,7 @@ class user_switching {
 	/**
 	 * Authenticates an old user by verifying the latest entry in the auth cookie.
 	 *
-	 * @param  WP_User $user A WP_User object (usually from the logged_in cookie).
+	 * @param WP_User $user A WP_User object (usually from the logged_in cookie).
 	 * @return bool Whether verification with the auth cookie passed.
 	 */
 	public static function authenticate_old_user( WP_User $user ) {
@@ -892,7 +862,7 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 	 *
 	 * @param int    $old_user_id The ID of the originating user, usually the current logged in user.
 	 * @param bool   $pop         Optional. Pop the latest user off the auth cookie, instead of appending the new one. Default false.
-	 * @param string $token       Optional. The old user's session token to store for later reuse.
+	 * @param string $token       Optional. The old user's session token to store for later reuse. Default empty string.
 	 */
 	function user_switching_set_olduser_cookie( $old_user_id, $pop = false, $token = '' ) {
 		$secure_auth_cookie    = user_switching::secure_auth_cookie();

--- a/user-switching.php
+++ b/user-switching.php
@@ -888,21 +888,27 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 			) );
 		}
 
+		$auth_cookie = json_encode( $auth_cookie );
+
 		/**
 		 * Fires immediately before the User Switching authentication cookie is set.
 		 *
+		 * The JSON-encoded auth cookie array is structured as such:
+		 *
+		 *     stdClass[] {
+		 *         Array of authentication cookies.
+		 *
+		 *         @type stdClass ...$0 {
+		 *             Information about the authentication instance.
+		 *
+		 *             @type string $cookie The authentication cookie value.
+		 *             @type string $token  The session token.
+		 *         }
+		 *     }
+		 *
 		 * @since 1.4.0
 		 *
-		 * @param stdClass[] $auth_cookie {
-		 *     Array of authentication cookies.
-		 *
-		 *     @type stdClass ...$0 {
-		 *         Information about the authentication instance.
-		 *
-		 *         @type string $cookie The authentication cookie value.
-		 *         @type string $token  The session token.
-		 *     }
-		 * }
+		 * @param string $auth_cookie JSON-encoded array of authentication cookies.
 		 * @param int    $expiration  The time when the authentication cookie expires as a UNIX timestamp.
 		 *                            Default is 48 hours from now.
 		 * @param int    $old_user_id User ID.
@@ -930,7 +936,7 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 			return;
 		}
 
-		setcookie( $auth_cookie_name, json_encode( $auth_cookie ), $expiration, SITECOOKIEPATH, COOKIE_DOMAIN, $secure_auth_cookie, true );
+		setcookie( $auth_cookie_name, $auth_cookie, $expiration, SITECOOKIEPATH, COOKIE_DOMAIN, $secure_auth_cookie, true );
 		setcookie( USER_SWITCHING_OLDUSER_COOKIE, $olduser_cookie, $expiration, COOKIEPATH, COOKIE_DOMAIN, $secure_olduser_cookie, true );
 	}
 }

--- a/user-switching.php
+++ b/user-switching.php
@@ -400,13 +400,7 @@ class user_switching {
 				$scheme = 'auth';
 			}
 
-			$old_cookie = end( $cookie );
-
-			if ( ! is_object( $old_cookie ) || ! isset( $old_cookie->cookie ) ) {
-				return false;
-			}
-
-			$old_user_id = wp_validate_auth_cookie( $old_cookie->cookie, $scheme );
+			$old_user_id = wp_validate_auth_cookie( end( $cookie ), $scheme );
 
 			if ( $old_user_id ) {
 				return ( $user->ID === $old_user_id );
@@ -882,10 +876,7 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 		if ( $pop ) {
 			array_pop( $auth_cookie );
 		} else {
-			array_push( $auth_cookie, (object) array(
-				'cookie' => wp_generate_auth_cookie( $old_user_id, $expiration, $scheme, $token ),
-				'token'  => $token,
-			) );
+			array_push( $auth_cookie, wp_generate_auth_cookie( $old_user_id, $expiration, $scheme, $token ) );
 		}
 
 		$auth_cookie = json_encode( $auth_cookie );
@@ -895,15 +886,10 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 		 *
 		 * The JSON-encoded auth cookie array is structured as such:
 		 *
-		 *     stdClass[] {
+		 *     string[] {
 		 *         Array of authentication cookies.
 		 *
-		 *         @type stdClass ...$0 {
-		 *             Information about the authentication instance.
-		 *
-		 *             @type string $cookie The authentication cookie value.
-		 *             @type string $token  The session token.
-		 *         }
+		 *         @type string ...$0 The authentication cookie value.
 		 *     }
 		 *
 		 * @since 1.4.0
@@ -980,13 +966,10 @@ if ( ! function_exists( 'user_switching_clear_olduser_cookie' ) ) {
 
 			$old_cookie = end( $auth_cookie );
 
-			if ( ! is_object( $old_cookie ) || ! isset( $old_cookie->cookie ) ) {
-				return;
-			}
-
-			$old_user_id = wp_validate_auth_cookie( $old_cookie->cookie, $scheme );
+			$old_user_id = wp_validate_auth_cookie( $old_cookie, $scheme );
 			if ( $old_user_id ) {
-				user_switching_set_olduser_cookie( $old_user_id, true, $old_cookie->token );
+				$parts = wp_parse_auth_cookie( $old_cookie, $scheme );
+				user_switching_set_olduser_cookie( $old_user_id, true, $parts['token'] );
 			}
 		}
 	}

--- a/user-switching.php
+++ b/user-switching.php
@@ -854,6 +854,8 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 	/**
 	 * Sets authorisation cookies containing the originating user information.
 	 *
+	 * @since 1.4.0 The `$token` parameter was added.
+	 *
 	 * @param int    $old_user_id The ID of the originating user, usually the current logged in user.
 	 * @param bool   $pop         Optional. Pop the latest user off the auth cookie, instead of appending the new one. Default false.
 	 * @param string $token       Optional. The old user's session token to store for later reuse. Default empty string.
@@ -884,17 +886,9 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 		/**
 		 * Fires immediately before the User Switching authentication cookie is set.
 		 *
-		 * The JSON-encoded auth cookie array is structured as such:
-		 *
-		 *     string[] {
-		 *         Array of authentication cookies.
-		 *
-		 *         @type string ...$0 The authentication cookie value.
-		 *     }
-		 *
 		 * @since 1.4.0
 		 *
-		 * @param string $auth_cookie JSON-encoded array of authentication cookies.
+		 * @param string $auth_cookie JSON-encoded array of authentication cookie values.
 		 * @param int    $expiration  The time when the authentication cookie expires as a UNIX timestamp.
 		 *                            Default is 48 hours from now.
 		 * @param int    $old_user_id User ID.
@@ -1035,11 +1029,11 @@ if ( ! function_exists( 'switch_to_user' ) ) {
 		$cookie_parts = wp_parse_auth_cookie( end( $auth_cookie ) );
 
 		if ( $set_old_user && $old_user_id ) {
-			// switching to another user
+			// Switching to another user
 			$new_token = '';
 			user_switching_set_olduser_cookie( $old_user_id, false, $old_token );
 		} else {
-			// switching back, either after being switched off or after being switched to another user
+			// Switching back, either after being switched off or after being switched to another user
 			$new_token = isset( $cookie_parts['token'] ) ? $cookie_parts['token'] : '';
 			user_switching_clear_olduser_cookie( false );
 		}

--- a/user-switching.php
+++ b/user-switching.php
@@ -1020,7 +1020,7 @@ if ( ! function_exists( 'user_switching_get_auth_cookie' ) ) {
 			$auth_cookie_name = USER_SWITCHING_COOKIE;
 		}
 
-		if ( isset( $_COOKIE[ $auth_cookie_name ] ) ) {
+		if ( isset( $_COOKIE[ $auth_cookie_name ] ) && is_string( $_COOKIE[ $auth_cookie_name ] ) ) {
 			$cookie = json_decode( wp_unslash( $_COOKIE[ $auth_cookie_name ] ) ); // WPCS: sanitization ok
 		}
 		if ( ! isset( $cookie ) || ! is_array( $cookie ) ) {

--- a/user-switching.php
+++ b/user-switching.php
@@ -1029,17 +1029,23 @@ if ( ! function_exists( 'switch_to_user' ) ) {
 			return false;
 		}
 
-		$old_user_id = ( is_user_logged_in() ) ? get_current_user_id() : false;
-		$old_token   = function_exists( 'wp_get_session_token' ) ? wp_get_session_token() : '';
+		$old_user_id  = ( is_user_logged_in() ) ? get_current_user_id() : false;
+		$old_token    = function_exists( 'wp_get_session_token' ) ? wp_get_session_token() : '';
+		$auth_cookie  = user_switching_get_auth_cookie();
+		$cookie_parts = wp_parse_auth_cookie( end( $auth_cookie ) );
 
 		if ( $set_old_user && $old_user_id ) {
+			// switching to another user
+			$new_token = '';
 			user_switching_set_olduser_cookie( $old_user_id, false, $old_token );
 		} else {
+			// switching back, either after being switched off or after being switched to another user
+			$new_token = isset( $cookie_parts['token'] ) ? $cookie_parts['token'] : '';
 			user_switching_clear_olduser_cookie( false );
 		}
 
 		wp_clear_auth_cookie();
-		wp_set_auth_cookie( $user_id, $remember );
+		wp_set_auth_cookie( $user_id, $remember, '', $new_token );
 		wp_set_current_user( $user_id );
 
 		if ( $set_old_user ) {


### PR DESCRIPTION
Fixes #20.

Work in progress. Lots more left to do. There is more complexity to implementing this than you might expect.

## Switching to a new user

* [x] Existing user session token should be retained in the switch stack
* [x] New session should be created for user being switched to
* [x] No unnecessary new sessions should be created for old user
* [x] Only one new session should be created for new user

## Switching off

* [x] Existing user session token should be retained in the switch stack
* [x] No unnecessary new sessions should be created for old user

## Switching back

* [x] Previous session for original user should be re-used
  - [x] Check if there's a token in the switch stack
  - [x] Verify session for token exists
  - [x] Re-use if it does, prevent switching if not
* [x] Current session for old user should be destroyed
  - [x] Only if switching _back_ to a session in the stack
* [x] No unnecessary new sessions should be created for old user
* [x] No unnecessary new sessions should be created for new (original) user

## Stretch goals

* [x] Add old user information to a new session when it's created. `attach_session_information`
* [x] Pass the old and new session tokens to the actions:
  - [x] `switch_to_user`
  - [x] `switch_back_user`
  - [x] `switch_off_user`