### PR TITLE
Forget current user's WooCommerce session when switching

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,7 +20,7 @@ This plugin allows you to quickly swap between user accounts in WordPress at the
  * Switch back: Instantly switch back to your originating account.
  * Switch off: Log out of your account but retain the ability to instantly switch back in again.
  * It's completely secure (see the *Security* section below).
- * Compatible with WordPress, WordPress Multisite, BuddyPress, and bbPress.
+ * Compatible with WordPress, WordPress Multisite, WooCommerce, BuddyPress, and bbPress.
 
 = Security =
 

--- a/user-switching.php
+++ b/user-switching.php
@@ -775,6 +775,23 @@ class user_switching {
 	}
 
 	/**
+	 * Instructs WooCommerce to forget the session for the current user, without deleting it.
+	 *
+	 * @param WooCommerce $wc The WooCommerce instance.
+	 */
+	public static function forget_woocommerce_session( WooCommerce $wc ) {
+		if ( ! property_exists( $wc, 'session' ) ) {
+			return false;
+		}
+
+		if ( ! method_exists( $wc->session, 'forget_session' ) ) {
+			return false;
+		}
+
+		$wc->session->forget_session();
+	}
+
+	/**
 	 * Filters a user's capabilities so they can be altered at runtime.
 	 *
 	 * This is used to:
@@ -1107,6 +1124,11 @@ if ( ! function_exists( 'switch_to_user' ) ) {
 			// When switching back, destroy the session for the old user
 			$manager = WP_Session_Tokens::get_instance( $old_user_id );
 			$manager->destroy( $old_token );
+		}
+
+		// When switching, instruct WooCommerce to forget about the current user's session
+		if ( function_exists( 'WC' ) ) {
+			user_switching::forget_woocommerce_session( WC() );
 		}
 
 		return $user;


### PR DESCRIPTION
Waiting on https://github.com/woocommerce/woocommerce/pull/21991 to land in WooCommerce 3.6.