### PR TITLE
Added filter user_switching_allow_switch to action_init

### DIFF
--- a/user-switching.php
+++ b/user-switching.php
@@ -151,7 +151,7 @@ class user_switching {
 				}
 
 				// Check authentication:
-				if ( ! current_user_can( 'switch_to_user', $user_id ) ) {
+				if ( ! apply_filters( 'user_switching_allow_switch', current_user_can( 'switch_to_user', $user_id ), $user_id ) ) {
 					wp_die( esc_html__( 'Could not switch users.', 'user-switching' ), 403 );
 				}
 


### PR DESCRIPTION
With some more backend uses of the plugin the ability to selectively allow a user to switch users is preferable to permanently or temporarily assigning the capability to users that normally wouldn't be able to.

Use Case (n=1):

A site with a front-end dashboard that allows those with administrator roles to switch between users for customer service or other administrative duties as needed.

Currently when on another user's dashboard you have to switch back to the administrator to then switch to a different user.

![Screen Shot 2020-01-06 at 3 17 23 AM](https://user-images.githubusercontent.com/9761464/71808405-51ad5200-3033-11ea-876e-1ff37dba03c2.png)
