### PR TITLE
Don't use core's `send_auth_cookies` filter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -165,7 +165,6 @@ In addition, User Switching respects the following filters from WordPress core w
 
 * `login_redirect` when switching to another user.
 * `logout_redirect` when switching off.
-* `send_auth_cookies` before setting any cookies.
 
 ## Changelog ##
 

--- a/readme.txt
+++ b/readme.txt
@@ -154,7 +154,6 @@ In addition, User Switching respects the following filters from WordPress core w
 
 * `login_redirect` when switching to another user.
 * `logout_redirect` when switching off.
-* `send_auth_cookies` before setting any cookies.
 
 == Changelog ==
 

--- a/tests/user-switching-test.php
+++ b/tests/user-switching-test.php
@@ -45,7 +45,7 @@ abstract class User_Switching_Test extends WP_UnitTestCase {
 			grant_super_admin( self::$testers['super']->ID );
 		}
 
-		add_filter( 'send_auth_cookies', '__return_false' );
+		add_filter( 'user_switching_send_auth_cookies', '__return_false' );
 	}
 
 	public function setUp() {

--- a/user-switching.php
+++ b/user-switching.php
@@ -1001,8 +1001,14 @@ if ( ! function_exists( 'user_switching_set_olduser_cookie' ) ) {
 		 */
 		do_action( 'set_olduser_cookie', $olduser_cookie, $expiration, $old_user_id, $scheme, $token );
 
-		/** This filter is documented in wp-includes/pluggable.php */
-		if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+		/**
+		 * Allows preventing auth cookies from actually being sent to the client.
+		 *
+		 * @since 1.5.4
+		 *
+		 * @param bool $send Whether to send auth cookies to the client.
+		 */
+		if ( ! apply_filters( 'user_switching_send_auth_cookies', true ) ) {
 			return;
 		}
 
@@ -1030,8 +1036,8 @@ if ( ! function_exists( 'user_switching_clear_olduser_cookie' ) ) {
 			 */
 			do_action( 'clear_olduser_cookie' );
 
-			/** This filter is documented in wp-includes/pluggable.php */
-			if ( ! apply_filters( 'send_auth_cookies', true ) ) {
+			/** This filter is documented in user-switching.php */
+			if ( ! apply_filters( 'user_switching_send_auth_cookies', true ) ) {
 				return;
 			}
 


### PR DESCRIPTION
See #48 

Plugins such as Jetpack (version 8.1.1+) can use the `send_auth_cookies` filter to prevent auth cookies from being sent. This is clearly the intended usage of this filter, but it means the switch back functionality can be broken.

To get around this, let's switch to a custom filter instead of using core's. This filter is only used during tests, so the change should be safe.