### PR TITLE
Added filter to disable output in footer on front end.

### DIFF
--- a/user-switching.php
+++ b/user-switching.php
@@ -548,11 +548,11 @@ class user_switching {
 		if ( is_admin_bar_showing() || did_action( 'wp_meta' ) ) {
 			return;
     }
-    
-    // Allow developers to disable this feature.
-    if ( ! apply_filters( 'user_switching_in_footer', true ) ) {
-      return;
-    }
+
+		// Allow developers to disable this feature.
+		if ( ! apply_filters( 'user_switching_in_footer', true ) ) {
+			return;
+		}
 
 		$old_user = self::get_old_user();
 

--- a/user-switching.php
+++ b/user-switching.php
@@ -549,7 +549,13 @@ class user_switching {
 			return;
 		}
 
-		// Allow developers to disable this feature.
+		/** 
+		 * Allow developers to disable the 'Switch back to {user}' link in WordPress footer. 
+		 * 
+		 * @since 1.5.5 
+		 * 
+		 * @param bool    $show_in_footer   Whether to show the 'Switch back to {user}' link in footer. 
+		 */
 		if ( ! apply_filters( 'user_switching_in_footer', true ) ) {
 			return;
 		}

--- a/user-switching.php
+++ b/user-switching.php
@@ -549,12 +549,12 @@ class user_switching {
 			return;
 		}
 
-		/** 
-		 * Allow developers to disable the 'Switch back to {user}' link in WordPress footer. 
-		 * 
-		 * @since 1.5.5 
-		 * 
-		 * @param bool    $show_in_footer   Whether to show the 'Switch back to {user}' link in footer. 
+		/**
+		 * Allow developers to disable the 'Switch back to {user}' link in WordPress footer.
+		 *
+		 * @since 1.5.5
+		 *
+		 * @param bool    $show_in_footer   Whether to show the 'Switch back to {user}' link in footer.
 		 */
 		if ( ! apply_filters( 'user_switching_in_footer', true ) ) {
 			return;

--- a/user-switching.php
+++ b/user-switching.php
@@ -554,7 +554,7 @@ class user_switching {
 		 *
 		 * @since 1.5.5
 		 *
-		 * @param bool    $show_in_footer   Whether to show the 'Switch back to {user}' link in footer.
+		 * @param bool $show_in_footer Whether to show the 'Switch back to {user}' link in footer.
 		 */
 		if ( ! apply_filters( 'user_switching_in_footer', true ) ) {
 			return;

--- a/user-switching.php
+++ b/user-switching.php
@@ -547,7 +547,12 @@ class user_switching {
 	public function action_wp_footer() {
 		if ( is_admin_bar_showing() || did_action( 'wp_meta' ) ) {
 			return;
-		}
+    }
+    
+    // Allow developers to disable this feature.
+    if ( ! apply_filters( 'user_switching_in_footer', true ) ) {
+      return;
+    }
 
 		$old_user = self::get_old_user();
 

--- a/user-switching.php
+++ b/user-switching.php
@@ -550,7 +550,7 @@ class user_switching {
 		}
 
 		/**
-		 * Allow developers to disable the 'Switch back to {user}' link in WordPress footer.
+		 * Allows the 'Switch back to {user}' link in the WordPress footer to be disabled.
 		 *
 		 * @since 1.5.5
 		 *

--- a/user-switching.php
+++ b/user-switching.php
@@ -547,7 +547,7 @@ class user_switching {
 	public function action_wp_footer() {
 		if ( is_admin_bar_showing() || did_action( 'wp_meta' ) ) {
 			return;
-    }
+		}
 
 		// Allow developers to disable this feature.
 		if ( ! apply_filters( 'user_switching_in_footer', true ) ) {


### PR DESCRIPTION
Hi @johnbillion,

I'm a happy, long-time `User Switching` user that thought it would be neat to allow disabling the user switching on front end with a filter within the plugin so I made this pull request.

What I currently do to achieve this is the following:

```php
<?php
function disable_user_switching_in_footer() {
    if ( array_key_exists( 'user_switching', $GLOBALS ) ) {
      remove_action( 'wp_footer', array( $GLOBALS['user_switching'], 'action_wp_footer' ) );
    }
}
add_action( 'init', 'disable_user_switching_in_footer' );
```

And with this change developers could do this instead:
```php
<?php
add_filter( 'user_switching_in_footer', '__return_false' );
```
PS: In the diff view I can see that my indentation seems wrong compared to your code.  I don't have much experience contributing to other people's projects so I hope I do this right. 😊