### PR TITLE
Add tr class to user edit screen

### DIFF
--- a/user-switching.php
+++ b/user-switching.php
@@ -104,7 +104,7 @@ class user_switching {
 		}
 
 		?>
-		<tr>
+		<tr class="user-switching-wrap">
 			<th scope="row"><?php echo esc_html_x( 'User Switching', 'User Switching title on user profile screen', 'user-switching' ); ?></th>
 			<td><a id="user_switching_switcher" href="<?php echo esc_url( $link ); ?>"><?php esc_html_e( 'Switch&nbsp;To', 'user-switching' ); ?></a></td>
 		</tr>


### PR DESCRIPTION
Add tr class as it is standard practice for new fields on the WP User Edit screen. This can allow for removing the fields like this https://wordpress.stackexchange.com/questions/307135/removing-wordpress-profile-fields-from-non-admins