### PR TITLE
Add CI testing for PHP 8

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php: ['7.3']
+        php: ['7.3','8.0']
         wp: ['*', 'dev-nightly']
       fail-fast: false
     name: WP ${{ matrix.wp }} / PHP ${{ matrix.php }}
@@ -48,7 +48,7 @@ jobs:
       run: |
         sudo systemctl start mysql.service
         composer install --prefer-dist
-        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="${{ matrix.wp }} || *"
+        composer require --dev --update-with-dependencies --prefer-dist --ignore-platform-reqs roots/wordpress="${{ matrix.wp }} || *"
 
     - name: Run the tests
       run: composer test:ft

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo systemctl start mysql.service
-        composer install --prefer-dist
+        composer install --prefer-dist --ignore-platform-reqs
         composer require --dev --update-with-dependencies --prefer-dist --ignore-platform-reqs roots/wordpress="${{ matrix.wp }} || *"
 
     - name: Run the tests

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"behat/mink-goutte-driver": "^1.2",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
 		"genesis/behat-fail-aid": "^2.0",
-		"johnbillion/php-docs-standards": "^1.2",
+		"johnbillion/php-docs-standards": "^2",
 		"paulgibbs/behat-wordpress-extension": "^3.3",
 		"php-stubs/wordpress-stubs": "^5.7",
 		"phpcompatibility/php-compatibility": "^9",


### PR DESCRIPTION
The plugin is PHP 8 compatible, but we don't have CI tests for it. This adds that.