### PR TITLE
Fix the functional tests on PHP 7.3

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/e2e.yml'
       - 'behat.yml'
+      - 'bin/test.sh'
       - 'composer.json'
       - 'features/**'
       - 'user-switching.php'
@@ -17,6 +18,7 @@ on:
     paths:
       - '.github/workflows/e2e.yml'
       - 'behat.yml'
+      - 'bin/test.sh'
       - 'composer.json'
       - 'features/**'
       - 'user-switching.php'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,8 +55,8 @@ jobs:
       uses: shivammathur/setup-php@2.7.0
       with:
         php-version: ${{ matrix.php }}
-        extensions: mysqli, xmlwriter
-        coverage: none
+        extensions: mysqli, xmlwriter, xdebug
+        ini-values: xdebug.mode="develop"
       env:
         fail-fast: true
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php: ['7.3','8.0']
+        php: ['7.4']
         wp: ['*', 'dev-nightly']
       fail-fast: false
     name: WP ${{ matrix.wp }} / PHP ${{ matrix.php }}
@@ -72,8 +72,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo systemctl start mysql.service
-        composer install --prefer-dist --ignore-platform-reqs
-        composer require --dev --update-with-dependencies --prefer-dist --ignore-platform-reqs roots/wordpress="${{ matrix.wp }} || *"
+        composer install --prefer-dist
+        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="${{ matrix.wp }} || *"
 
     - name: Run the tests
       run: composer test:ft

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-# -e Exit immediately if a pipeline returns a non-zero status
-# -x Print a trace of commands and their arguments after they are expanded and before they are executed
-set -ex
+# -e          Exit immediately if a pipeline returns a non-zero status
+# -o pipefail Produce a failure return code if any command errors
+set -eo pipefail
 
 # Specify the directory where the WordPress installation lives:
 WP_CORE_DIR="${PWD}/tests/wordpress"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# -e Exit immediately if a pipeline returns a non-zero status
+# -x Print a trace of commands and their arguments after they are expanded and before they are executed
+set -ex
+
 # Specify the directory where the WordPress installation lives:
 WP_CORE_DIR="${PWD}/tests/wordpress"
 
@@ -24,7 +28,7 @@ $WP language plugin install user-switching it_IT
 
 # Run the functional tests:
 BEHAT_PARAMS='{"extensions" : {"WordHat\\Extension" : {"path" : "'$WP_CORE_DIR'"}}}' \
-	./vendor/bin/behat --colors "$1"
+	./vendor/bin/behat --colors --strict "$1"
 
 # Stop the PHP web server:
 kill $!

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -28,7 +28,8 @@ $WP language plugin install user-switching it_IT
 
 # Run the functional tests:
 BEHAT_PARAMS='{"extensions" : {"WordHat\\Extension" : {"path" : "'$WP_CORE_DIR'"}}}' \
-	./vendor/bin/behat --colors --strict "$1"
+	./vendor/bin/behat --colors --strict "$1" \
+	|| BEHAT_EXIT_CODE=$? && kill $! && exit $BEHAT_EXIT_CODE
 
 # Stop the PHP web server:
 kill $!


### PR DESCRIPTION
The functional tests are actually exiting with a fatal error on PHP 7.3 but the shell script doesn't surface the non-zero exit code. The underlying problem is because `--ignore-platform-reqs` is being used. Need to fix it all.