### PR TITLE
Add caching for WP-CLI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,9 +24,9 @@ on:
       - 'composer.json'
       - 'features/**'
       - 'user-switching.php'
-  # Once weekly on Wednesdays at 06:00 UTC.
+  # Once weekly on Wednesdays at 07:00 UTC.
   schedule:
-    - cron: '0 6 * * 3'
+    - cron: '0 7 * * 3'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ jobs:
       env:
         cache-name: cache-wp-cli-assets
       with:
-        path: $WP_CLI_CACHE_DIR
+        path: ${{ env.WP_CLI_CACHE_DIR }}
         key: wp-cli-${{ hashFiles('composer.json') }}
 
     - name: Install PHP

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,6 +29,9 @@ on:
     - cron: '0 6 * * 3'
   workflow_dispatch:
 
+env:
+  WP_CLI_CACHE_DIR: "~/.wp-cli/cache"
+
 jobs:
   build:
     strategy:
@@ -54,6 +57,14 @@ jobs:
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+
+    - name: WP-CLI cache
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-wp-cli-assets
+      with:
+        path: $WP_CLI_CACHE_DIR
+        key: wp-cli-${{ hashFiles('composer.json') }}
 
     - name: Install PHP
       uses: shivammathur/setup-php@2.7.0


### PR DESCRIPTION
So it doesn't re-download language packs for every test run.