### PR TITLE
Correct the WP version installer

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,9 @@ jobs:
         php: ['8.1','8.0','7.4','5.6']
         wp: ['*', 'dev-nightly']
         include:
-          # Oldest version that supports user locales:
+          # Oldest version that passes the `$token` parameter to session actions:
           - php: '5.6'
-            wp: '4.7'
+            wp: '4.9'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,9 @@ jobs:
         php: ['8.1','8.0','7.4','5.6']
         wp: ['*', 'dev-nightly']
         include:
-          # Oldest version supported by User Switching:
+          # Oldest version available from Roots:
           - php: 5.6
-            wp: 3.7
+            wp: 4.0
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04
@@ -85,7 +85,7 @@ jobs:
           phpstan/phpstan-phpunit \
           --dev
         composer install --prefer-dist
-        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="${{ matrix.wp }} || *"
+        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="${{ matrix.wp }}"
         mysqladmin -uroot -proot create wordpress_test
 
     - name: Run the tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,7 @@ jobs:
         wp: ['*', 'dev-nightly']
         include:
           # Oldest version that supports user locales:
-          - php: '5.6'
+          - php: '7.1'
             wp: '4.7'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,9 @@ jobs:
         php: ['8.1','8.0','7.4','5.6']
         wp: ['*', 'dev-nightly']
         include:
-          # Oldest version that passes the `$token` parameter to session actions:
+          # Oldest version that supports user locales:
           - php: '5.6'
-            wp: '4.9'
+            wp: '4.7'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,9 @@ jobs:
         php: ['8.1','8.0','7.4','5.6']
         wp: ['*', 'dev-nightly']
         include:
-          # Oldest version available from Roots:
+          # Oldest version that supports language packs:
           - php: '5.6'
-            wp: '4.0'
+            wp: '4.1'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,9 @@ jobs:
         php: ['8.1','8.0','7.4','5.6']
         wp: ['*', 'dev-nightly']
         include:
-          # Oldest version that supports language packs:
+          # Oldest version that supports user locales:
           - php: '5.6'
-            wp: '4.1'
+            wp: '4.7'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,8 +37,8 @@ jobs:
         wp: ['*', 'dev-nightly']
         include:
           # Oldest version available from Roots:
-          - php: 5.6
-            wp: 4.0
+          - php: '5.6'
+            wp: '4.0'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,9 @@ jobs:
         php: ['8.1','8.0','7.4','5.6']
         wp: ['*', 'dev-nightly']
         include:
-          # Oldest version that supports user locales:
+          # Oldest version that passes the `$token` parameter to session actions:
           - php: '5.6'
-            wp: '4.7'
+            wp: '4.9'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
         wp: ['*', 'dev-nightly']
         include:
           # Oldest version available from Roots:
-          - php: 5.6
-            wp: 4.0
+          - php: '5.6'
+            wp: '4.0'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,9 @@ jobs:
         php: ['8.1','8.0','7.4','5.6']
         wp: ['*', 'dev-nightly']
         include:
-          # Oldest version available from Roots:
+          # Oldest version that supports language packs:
           - php: '5.6'
-            wp: '4.0'
+            wp: '4.1'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,9 @@ jobs:
         php: ['8.1','8.0','7.4','5.6']
         wp: ['*', 'dev-nightly']
         include:
-          # Oldest version supported by User Switching:
+          # Oldest version available from Roots:
           - php: 5.6
-            wp: 3.7
+            wp: 4.0
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04
@@ -83,7 +83,7 @@ jobs:
           phpstan/phpstan-phpunit \
           --dev
         composer install --prefer-dist
-        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="${{ matrix.wp }} || *"
+        composer require --dev --update-with-dependencies --prefer-dist roots/wordpress="${{ matrix.wp }}"
         mysqladmin -uroot -proot create wordpress_test
 
     - name: Run the tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         wp: ['*', 'dev-nightly']
         include:
           # Oldest version that passes the `$token` parameter to session actions:
-          - php: '5.6'
+          - php: '7.2'
             wp: '4.9'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,9 @@ jobs:
         php: ['8.1','8.0','7.4','5.6']
         wp: ['*', 'dev-nightly']
         include:
-          # Oldest version that supports language packs:
+          # Oldest version that supports user locales:
           - php: '5.6'
-            wp: '4.1'
+            wp: '4.7'
       fail-fast: false
     name: "WP ${{ matrix.wp == '*' && 'latest' || matrix.wp }} / PHP ${{ matrix.php }}"
     runs-on: ubuntu-18.04


### PR DESCRIPTION
3.7 isn't actually available from Roots so defaulted to latest.