### PR TITLE
Exclude `.editorconfig` from dist ZIP

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -8,6 +8,7 @@ tests
 vendor
 
 # Files
+.editorconfig
 .distignore
 .gitignore
 codeception.dist.yml


### PR DESCRIPTION
Prevents the `.editorconfig` file from being added to the WordPress.org plugin SVN repository.