### PR TITLE
Redirect to the current post, term, user, or comment being edited when switching off

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
 		"wp-cli/db-command": "^2",
 		"wp-cli/extension-command": "^2",
 		"wp-cli/language-command": "^2",
+		"wp-cli/rewrite-command": "^2",
 		"wp-coding-standards/wpcs": "^2"
 	},
 	"autoload-dev": {

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -32,7 +32,6 @@ class AcceptanceTester extends \Codeception\Actor {
 	 * Switch off
 	 */
 	public function switchOff() {
-		$this->amOnAdminPage( '/' );
 		$this->click( 'Switch Off' );
 	}
 

--- a/tests/acceptance/Cest.php
+++ b/tests/acceptance/Cest.php
@@ -9,6 +9,7 @@ class Cest {
 
 		# Install WordPress:
 		$I->cli( 'core install --title="Example" --admin_user="admin" --admin_password="admin" --admin_email="admin@example.com" --skip-email' );
+		$I->cli( 'rewrite structure "%postname%"' );
 
 		# Activate the plugin:
 		$I->cli( 'plugin activate user-switching' );

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -19,10 +19,11 @@ class SwitchOffCest extends Cest {
 		$I->amOnAdminPage( '/' );
 		$I->switchOff();
 		$I->amLoggedOut();
+		$I->seeCurrentUrlEquals( '?switched_off=true' );
 
 		$I->switchBack( 'admin' );
+		$I->seeCurrentUrlEquals( '/?user_switched=true&switched_back=true' );
 		$I->amLoggedInAs( 'admin' );
-		$I->dontSeeInCurrentUrl( '/wp-admin' );
 	}
 
 	public function SwitchOffFromDashboardAndBackFromLoginScreen( AcceptanceTester $I ) {
@@ -30,9 +31,11 @@ class SwitchOffCest extends Cest {
 		$I->amOnAdminPage( '/' );
 		$I->switchOff();
 		$I->amLoggedOut();
+		$I->seeCurrentUrlEquals( '?switched_off=true' );
 
-		$I->amOnPage( 'wp-login.php' ); // $I->amOnPage($I->getLoginUrl());
+		$I->amOnPage( 'wp-login.php' );
 		$I->switchBack( 'admin' );
+		$I->seeCurrentUrlEquals( '/wp-admin/users.php?user_switched=true&switched_back=true' );
 		$I->seeAdminSuccessNotice( 'Switched back to admin (admin)' );
 		$I->amLoggedInAs( 'admin' );
 	}

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -16,8 +16,8 @@ class SwitchOffCest extends Cest {
 		$I->loginAsAdmin();
 		$I->amOnAdminPage( '/' );
 		$I->switchOff();
-		$I->amLoggedOut();
 		$I->seeCurrentUrlEquals( '?switched_off=true' );
+		$I->amLoggedOut();
 
 		$I->switchBack( 'admin' );
 		$I->seeCurrentUrlEquals( '/?user_switched=true&switched_back=true' );
@@ -28,8 +28,8 @@ class SwitchOffCest extends Cest {
 		$I->loginAsAdmin();
 		$I->amOnAdminPage( '/' );
 		$I->switchOff();
-		$I->amLoggedOut();
 		$I->seeCurrentUrlEquals( '?switched_off=true' );
+		$I->amLoggedOut();
 
 		$I->amOnPage( 'wp-login.php' );
 		$I->switchBack( 'admin' );
@@ -46,8 +46,8 @@ class SwitchOffCest extends Cest {
 		] );
 		$I->amEditingPostWithId( $id );
 		$I->switchOff();
-		$I->amLoggedOut();
 		$I->seeCurrentUrlEquals( '/hello-world?switched_off=true' );
+		$I->amLoggedOut();
 	}
 
 	public function SwitchOffFromDraftPostEditingScreen( AcceptanceTester $I ) {
@@ -58,7 +58,7 @@ class SwitchOffCest extends Cest {
 		] );
 		$I->amEditingPostWithId( $id );
 		$I->switchOff();
-		$I->amLoggedOut();
 		$I->seeCurrentUrlEquals( '?switched_off=true' );
+		$I->amLoggedOut();
 	}
 }

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -50,4 +50,17 @@ class SwitchOffCest extends Cest {
 		$I->amLoggedOut();
 		$I->seeCurrentUrlEquals( '/hello-world?switched_off=true' );
 	}
+
+	public function SwitchOffFromDraftPostEditingScreen( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$id = $I->havePostInDatabase( [
+			'post_type' => 'post',
+			'post_status' => 'draft',
+			'post_name' => 'hello-world',
+		] );
+		$I->amEditingPostWithId( $id );
+		$I->switchOff();
+		$I->amLoggedOut();
+		$I->seeCurrentUrlEquals( '?switched_off=true' );
+	}
 }

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -41,7 +41,6 @@ class SwitchOffCest extends Cest {
 	public function SwitchOffFromPublishedPostEditingScreen( AcceptanceTester $I ) {
 		$I->loginAsAdmin();
 		$id = $I->havePostInDatabase( [
-			'post_type' => 'post',
 			'post_status' => 'publish',
 			'post_name' => 'hello-world',
 		] );
@@ -54,7 +53,6 @@ class SwitchOffCest extends Cest {
 	public function SwitchOffFromDraftPostEditingScreen( AcceptanceTester $I ) {
 		$I->loginAsAdmin();
 		$id = $I->havePostInDatabase( [
-			'post_type' => 'post',
 			'post_status' => 'draft',
 			'post_name' => 'hello-world',
 		] );

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -46,7 +46,15 @@ class SwitchOffCest extends Cest {
 		] );
 		$I->amEditingPostWithId( $id );
 		$I->switchOff();
-		$I->seeCurrentUrlEquals( '/hello-world?switched_off=true' );
+
+		try {
+			// WordPress >= 5.7:
+			$I->seeCurrentUrlEquals( '/hello-world?switched_off=true' );
+		} catch ( \PHPUnit\Framework\ExpectationFailedException $e ) {
+			// WordPress < 5.7:
+			$I->seeCurrentUrlEquals( '?switched_off=true' );
+		}
+
 		$I->amLoggedOut();
 	}
 

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -67,7 +67,7 @@ class SwitchOffCest extends Cest {
 		$id = $I->haveUserInDatabase( 'example', 'editor' );
 		// https://github.com/lucatume/wp-browser/pull/586
 		// $I->amEditingUserWithId( $id );
-		$I->amOnAdminPage('/user-edit.php?user_id=' . $id);
+		$I->amOnAdminPage( '/user-edit.php?user_id=' . $id );
 		$I->switchOff();
 		$I->seeCurrentUrlEquals( '/author/example?switched_off=true' );
 		$I->amLoggedOut();

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -97,4 +97,42 @@ class SwitchOffCest extends Cest {
 		$I->seeCurrentUrlEquals( '/author/example?switched_off=true' );
 		$I->amLoggedOut();
 	}
+
+	public function SwitchOffFromApprovedCommentEditingScreen( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$postId = $I->havePostInDatabase( [
+			'post_status' => 'publish',
+			'post_name' => 'leave-a-comment',
+		] );
+		$commentId = $I->haveCommentInDatabase( $postId, [
+			'comment_approved' => '1',
+		] );
+		$I->amOnAdminPage( '/comment.php?action=editcomment&c=' . $commentId );
+		$I->switchOff();
+		$I->seeCurrentUrlEquals( '/leave-a-comment?switched_off=true#comment-' . $commentId );
+		$I->amLoggedOut();
+	}
+
+	public function SwitchOffFromUnapprovedCommentEditingScreen( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$postId = $I->havePostInDatabase( [
+			'post_status' => 'publish',
+			'post_name' => 'leave-a-comment',
+		] );
+		$commentId = $I->haveCommentInDatabase( $postId, [
+			'comment_approved' => '0',
+		] );
+		$I->amOnAdminPage( '/comment.php?action=editcomment&c=' . $commentId );
+		$I->switchOff();
+
+		try {
+			// WordPress >= 5.7:
+			$I->seeCurrentUrlEquals( '/leave-a-comment?switched_off=true' );
+		} catch ( \PHPUnit\Framework\ExpectationFailedException $e ) {
+			// WordPress < 5.7:
+			$I->seeCurrentUrlEquals( '?switched_off=true' );
+		}
+
+		$I->amLoggedOut();
+	}
 }

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -39,4 +39,17 @@ class SwitchOffCest extends Cest {
 		$I->seeAdminSuccessNotice( 'Switched back to admin (admin)' );
 		$I->amLoggedInAs( 'admin' );
 	}
+
+	public function SwitchOffFromPublishedPostEditingScreen( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$id = $I->havePostInDatabase( [
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_name' => 'hello-world',
+		] );
+		$I->amEditingPostWithId( $id );
+		$I->switchOff();
+		$I->amLoggedOut();
+		$I->seeCurrentUrlEquals( '/hello-world?switched_off=true' );
+	}
 }

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -10,8 +10,6 @@ class SwitchOffCest extends Cest {
 		$I->comment( 'As an administrator' );
 		$I->comment( 'I need to be able to switch off' );
 		$I->comment( 'In order to view the site without logging out completely' );
-
-		$I->haveUserInDatabase( 'editor', 'editor' );
 	}
 
 	public function SwitchOffFromDashboardAndBackFromFrontEnd( AcceptanceTester $I ) {

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -61,4 +61,15 @@ class SwitchOffCest extends Cest {
 		$I->seeCurrentUrlEquals( '?switched_off=true' );
 		$I->amLoggedOut();
 	}
+
+	public function SwitchOffFromUserEditingScreen( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$id = $I->haveUserInDatabase( 'example', 'editor' );
+		// https://github.com/lucatume/wp-browser/pull/586
+		// $I->amEditingUserWithId( $id );
+		$I->amOnAdminPage('/user-edit.php?user_id=' . $id);
+		$I->switchOff();
+		$I->seeCurrentUrlEquals( '/author/example?switched_off=true' );
+		$I->amLoggedOut();
+	}
 }

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Acceptance tests for switching off.
+ */
+
+class SwitchOffCest extends Cest {
+	public function _before( AcceptanceTester $I ) {
+		parent::_before( $I );
+
+		$I->comment( 'As an administrator' );
+		$I->comment( 'I need to be able to switch off' );
+		$I->comment( 'In order to view the site without logging out completely' );
+
+		$I->haveUserInDatabase( 'editor', 'editor' );
+	}
+
+	public function SwitchOffFromDashboardAndBackFromFrontEnd( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$I->amOnAdminPage( '/' );
+		$I->switchOff();
+		$I->amLoggedOut();
+
+		$I->switchBack( 'admin' );
+		$I->amLoggedInAs( 'admin' );
+		$I->dontSeeInCurrentUrl( '/wp-admin' );
+	}
+
+	public function SwitchOffFromDashboardAndBackFromLoginScreen( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$I->amOnAdminPage( '/' );
+		$I->switchOff();
+		$I->amLoggedOut();
+
+		$I->amOnPage( 'wp-login.php' ); // $I->amOnPage($I->getLoginUrl());
+		$I->switchBack( 'admin' );
+		$I->seeAdminSuccessNotice( 'Switched back to admin (admin)' );
+		$I->amLoggedInAs( 'admin' );
+	}
+}

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -70,6 +70,23 @@ class SwitchOffCest extends Cest {
 		$I->amLoggedOut();
 	}
 
+	public function SwitchOffFromTermEditingScreen( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$term = $I->haveTermInDatabase( 'hello', 'category' );
+		$I->amOnAdminPage( '/term.php?taxonomy=category&tag_ID=' . $term[0] );
+		$I->switchOff();
+
+		try {
+			// WordPress >= 5.1:
+			$I->seeCurrentUrlEquals( '/category/hello?switched_off=true' );
+		} catch ( \PHPUnit\Framework\ExpectationFailedException $e ) {
+			// WordPress < 5.1:
+			$I->seeCurrentUrlEquals( '?switched_off=true' );
+		}
+
+		$I->amLoggedOut();
+	}
+
 	public function SwitchOffFromUserEditingScreen( AcceptanceTester $I ) {
 		$I->loginAsAdmin();
 		$id = $I->haveUserInDatabase( 'example', 'editor' );

--- a/tests/acceptance/SwitchUserCest.php
+++ b/tests/acceptance/SwitchUserCest.php
@@ -12,7 +12,7 @@ class SwitchUserCest extends Cest {
 		$I->comment( 'In order to access different user accounts' );
 	}
 
-	public function SwitchToEditorAndBack( AcceptanceTester $I ) {
+	public function SwitchToEditorThenBackFromFrontEnd( AcceptanceTester $I ) {
 		$I->loginAsAdmin();
 		$I->haveUserInDatabase( 'editor', 'editor' );
 
@@ -21,9 +21,24 @@ class SwitchUserCest extends Cest {
 		$I->seeAdminSuccessNotice( 'Switched to editor' );
 		$I->amLoggedInAs( 'editor' );
 
-		$I->amOnAdminPage( '/' );
+		$I->amOnPage( '/' );
 		$I->switchBack( 'admin' );
-		$I->seeCurrentUrlEquals( '/wp-admin/?user_switched=true&switched_back=true' );
+		$I->seeCurrentUrlEquals( '/?user_switched=true&switched_back=true' );
+		$I->amLoggedInAs( 'admin' );
+	}
+
+	public function SwitchToEditorThenBackFromAdminArea( AcceptanceTester $I ) {
+		$I->loginAsAdmin();
+		$I->haveUserInDatabase( 'editor', 'editor' );
+
+		$I->switchToUser( 'editor' );
+		$I->seeCurrentUrlEquals( '/wp-admin/?user_switched=true' );
+		$I->seeAdminSuccessNotice( 'Switched to editor' );
+		$I->amLoggedInAs( 'editor' );
+
+		$I->amOnAdminPage( 'tools.php' );
+		$I->switchBack( 'admin' );
+		$I->seeCurrentUrlEquals( '/wp-admin/tools.php?user_switched=true&switched_back=true' );
 		$I->seeAdminSuccessNotice( 'Switched back to admin' );
 		$I->amLoggedInAs( 'admin' );
 	}

--- a/tests/acceptance/SwitchUserCest.php
+++ b/tests/acceptance/SwitchUserCest.php
@@ -25,13 +25,4 @@ class SwitchUserCest extends Cest {
 		$I->seeAdminSuccessNotice( 'Switched back to admin' );
 		$I->amLoggedInAs( 'admin' );
 	}
-
-	public function SwitchOffAndBack( AcceptanceTester $I ) {
-		$I->loginAsAdmin();
-		$I->switchOff();
-		$I->amLoggedOut();
-
-		$I->switchBack( 'admin' );
-		$I->amLoggedInAs( 'admin' );
-	}
 }

--- a/tests/acceptance/SwitchUserCest.php
+++ b/tests/acceptance/SwitchUserCest.php
@@ -10,12 +10,12 @@ class SwitchUserCest extends Cest {
 		$I->comment( 'As an administrator' );
 		$I->comment( 'I need to be able to switch between users' );
 		$I->comment( 'In order to access different user accounts' );
-
-		$I->haveUserInDatabase( 'editor', 'editor' );
 	}
 
 	public function SwitchToEditorAndBack( AcceptanceTester $I ) {
 		$I->loginAsAdmin();
+		$I->haveUserInDatabase( 'editor', 'editor' );
+
 		$I->switchToUser( 'editor' );
 		$I->seeCurrentUrlEquals( '/wp-admin/?user_switched=true' );
 		$I->seeAdminSuccessNotice( 'Switched to editor' );

--- a/tests/acceptance/SwitchUserCest.php
+++ b/tests/acceptance/SwitchUserCest.php
@@ -17,11 +17,13 @@ class SwitchUserCest extends Cest {
 	public function SwitchToEditorAndBack( AcceptanceTester $I ) {
 		$I->loginAsAdmin();
 		$I->switchToUser( 'editor' );
+		$I->seeCurrentUrlEquals( '/wp-admin/?user_switched=true' );
 		$I->seeAdminSuccessNotice( 'Switched to editor' );
 		$I->amLoggedInAs( 'editor' );
 
 		$I->amOnAdminPage( '/' );
 		$I->switchBack( 'admin' );
+		$I->seeCurrentUrlEquals( '/wp-admin/?user_switched=true&switched_back=true' );
 		$I->seeAdminSuccessNotice( 'Switched back to admin' );
 		$I->amLoggedInAs( 'admin' );
 	}

--- a/user-switching.php
+++ b/user-switching.php
@@ -369,7 +369,17 @@ class user_switching {
 			$redirect_to = apply_filters( 'login_redirect', $redirect_to, $requested_redirect_to, $new_user );
 		}
 
-		return $redirect_to;
+		/**
+		 * Filters the redirect location after a user switches to another account or switches off.
+		 *
+		 * @since x.y.z
+		 *
+		 * @param string       $redirect_to   The target redirect location, or an empty string if none is specified.
+		 * @param string|null  $redirect_type The redirect type, see the `user_switching::REDIRECT_*` constants.
+		 * @param WP_User|null $new_user      The user being switched to, or null if there is none.
+		 * @param WP_User|null $old_user      The user being switched from, or null if there is none.
+		 */
+		return apply_filters( 'user_switching_redirect_to', $redirect_to, $redirect_type, $new_user, $old_user );
 	}
 
 	/**

--- a/user-switching.php
+++ b/user-switching.php
@@ -350,13 +350,22 @@ class user_switching {
 			$comment = get_comment( absint( $_GET['redirect_to_comment'] ) );
 
 			if ( $comment instanceof WP_Comment ) {
-				// @todo check comment status and fall back to linking to its post
-				$link = get_comment_link( $comment );
+				if ( 'approved' === wp_get_comment_status( $comment ) ) {
+					$link = get_comment_link( $comment );
 
-				if ( is_string( $link ) ) {
-					$redirect_to = $link;
-					$requested_redirect_to = $link;
-					$redirect_type = self::REDIRECT_TYPE_COMMENT;
+					if ( is_string( $link ) ) {
+						$redirect_to = $link;
+						$requested_redirect_to = $link;
+						$redirect_type = self::REDIRECT_TYPE_COMMENT;
+					}
+				} elseif ( function_exists( 'is_post_publicly_viewable' ) && is_post_publicly_viewable( (int) $comment->comment_post_ID ) ) {
+					$link = get_permalink( (int) $comment->comment_post_ID );
+
+					if ( is_string( $link ) ) {
+						$redirect_to = $link;
+						$requested_redirect_to = $link;
+						$redirect_type = self::REDIRECT_TYPE_POST;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
If a user switches off while they're on the editing screen for a post, term, user, or comment, the most useful place to redirect them to is the permalink for that item if it's publicly viewable.