### PR TITLE
Clean up user-facing messages by removing the user login in brackets

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -50,9 +50,8 @@ class AcceptanceTester extends \Codeception\Actor {
 		);
 
 		$this->click( sprintf(
-			'Switch back to %1$s (%2$s)',
-			$display_name,
-			$user_login
+			'Switch back to %s',
+			$display_name
 		) );
 	}
 

--- a/tests/acceptance/SwitchFromEnglishCest.php
+++ b/tests/acceptance/SwitchFromEnglishCest.php
@@ -27,12 +27,12 @@ class SwitchFromEnglishCest extends Cest {
 		$I->loginAsAdmin();
 		$I->switchToUser( 'autore' );
 		$I->canSeeThePageInLanguage( 'it-IT' );
-		$I->seeAdminSuccessNotice( 'Switched to Autore' );
+		$I->seeAdminSuccessNotice( 'Switched to Autore.' );
 		$I->canSeeTheElementInLanguage( '#user_switching p', 'en-US' );
 
 		$I->amOnAdminPage( '/' );
 		$I->switchBackTo( 'admin' );
 		$I->canSeeThePageInLanguage( 'en-US' );
-		$I->seeAdminSuccessNotice( 'Switched back to admin' );
+		$I->seeAdminSuccessNotice( 'Switched back to admin.' );
 	}
 }

--- a/tests/acceptance/SwitchOffCest.php
+++ b/tests/acceptance/SwitchOffCest.php
@@ -34,7 +34,7 @@ class SwitchOffCest extends Cest {
 		$I->amOnPage( 'wp-login.php' );
 		$I->switchBackTo( 'admin' );
 		$I->seeCurrentUrlEquals( '/wp-admin/users.php?user_switched=true&switched_back=true' );
-		$I->seeAdminSuccessNotice( 'Switched back to admin (admin)' );
+		$I->seeAdminSuccessNotice( 'Switched back to admin.' );
 		$I->amLoggedInAs( 'admin' );
 	}
 

--- a/tests/acceptance/SwitchToEnglishCest.php
+++ b/tests/acceptance/SwitchToEnglishCest.php
@@ -30,12 +30,12 @@ class SwitchToEnglishCest extends Cest {
 		$I->loginAs( 'admin_it', 'admin_it' );
 		$I->switchToUser( 'author_en' );
 		$I->canSeeThePageInLanguage( 'en-US' );
-		$I->seeAdminSuccessNotice( 'Cambiato a Author EN' );
+		$I->seeAdminSuccessNotice( 'Cambiato a Author EN.' );
 		$I->canSeeTheElementInLanguage( '#user_switching p', 'it-IT' );
 
 		$I->amOnAdminPage( '/' );
 		$I->switchBackTo( 'admin_it' );
 		$I->canSeeThePageInLanguage( 'it-IT' );
-		$I->seeAdminSuccessNotice( 'Tornato a Admin IT' );
+		$I->seeAdminSuccessNotice( 'Tornato a Admin IT.' );
 	}
 }

--- a/tests/acceptance/SwitchUserCest.php
+++ b/tests/acceptance/SwitchUserCest.php
@@ -18,7 +18,7 @@ class SwitchUserCest extends Cest {
 
 		$I->switchToUser( 'editor' );
 		$I->seeCurrentUrlEquals( '/wp-admin/?user_switched=true' );
-		$I->seeAdminSuccessNotice( 'Switched to editor' );
+		$I->seeAdminSuccessNotice( 'Switched to editor.' );
 		$I->amLoggedInAs( 'editor' );
 
 		$I->amOnPage( '/' );
@@ -33,13 +33,13 @@ class SwitchUserCest extends Cest {
 
 		$I->switchToUser( 'editor' );
 		$I->seeCurrentUrlEquals( '/wp-admin/?user_switched=true' );
-		$I->seeAdminSuccessNotice( 'Switched to editor' );
+		$I->seeAdminSuccessNotice( 'Switched to editor.' );
 		$I->amLoggedInAs( 'editor' );
 
 		$I->amOnAdminPage( 'tools.php' );
 		$I->switchBackTo( 'admin' );
 		$I->seeCurrentUrlEquals( '/wp-admin/tools.php?user_switched=true&switched_back=true' );
-		$I->seeAdminSuccessNotice( 'Switched back to admin' );
+		$I->seeAdminSuccessNotice( 'Switched back to admin.' );
 		$I->amLoggedInAs( 'admin' );
 	}
 }

--- a/user-switching.php
+++ b/user-switching.php
@@ -427,12 +427,7 @@ class user_switching {
 					$message = '';
 					$just_switched = isset( $_GET['user_switched'] );
 					if ( $just_switched ) {
-						$message = esc_html( sprintf(
-							/* Translators: 1: user display name; 2: username; */
-							__( 'Switched to %1$s (%2$s).', 'user-switching' ),
-							$user->display_name,
-							$user->user_login
-						) );
+						$message = esc_html( self::switched_to_message( $user ) );
 					}
 					$switch_back_url = add_query_arg( array(
 						'redirect_to' => urlencode( self::current_url() ),
@@ -441,12 +436,7 @@ class user_switching {
 					$message .= sprintf(
 						' <a href="%s">%s</a>.',
 						esc_url( $switch_back_url ),
-						esc_html( sprintf(
-							/* Translators: 1: user display name; 2: username; */
-							__( 'Switch back to %1$s (%2$s)', 'user-switching' ),
-							$old_user->display_name,
-							$old_user->user_login
-						) )
+						esc_html( self::switch_back_message( $old_user ) )
 					);
 
 					/**
@@ -480,19 +470,9 @@ class user_switching {
 				<p>
 				<?php
 					if ( isset( $_GET['switched_back'] ) ) {
-						echo esc_html( sprintf(
-							/* Translators: 1: user display name; 2: username; */
-							__( 'Switched back to %1$s (%2$s).', 'user-switching' ),
-							$user->display_name,
-							$user->user_login
-						) );
+						echo esc_html( self::switched_back_message( $user ) );
 					} else {
-						echo esc_html( sprintf(
-							/* Translators: 1: user display name; 2: username; */
-							__( 'Switched to %1$s (%2$s).', 'user-switching' ),
-							$user->display_name,
-							$user->user_login
-						) );
+						echo esc_html( self::switched_to_message( $user ) );
 					}
 				?>
 				</p>
@@ -565,12 +545,7 @@ class user_switching {
 			$wp_admin_bar->add_node( array(
 				'parent' => $parent,
 				'id' => 'switch-back',
-				'title' => esc_html( sprintf(
-					/* Translators: 1: user display name; 2: username; */
-					__( 'Switch back to %1$s (%2$s)', 'user-switching' ),
-					$old_user->display_name,
-					$old_user->user_login
-				) ),
+				'title' => esc_html( self::switch_back_message( $old_user ) ),
 				'href' => add_query_arg( array(
 					'redirect_to' => urlencode( self::current_url() ),
 				), self::switch_back_url( $old_user ) ),
@@ -601,12 +576,7 @@ class user_switching {
 				$wp_admin_bar->add_node( array(
 					'parent' => 'edit',
 					'id' => 'author-switch-back',
-					'title' => esc_html( sprintf(
-						/* Translators: 1: user display name; 2: username; */
-						__( 'Switch back to %1$s (%2$s)', 'user-switching' ),
-						$old_user->display_name,
-						$old_user->user_login
-					) ),
+					'title' => esc_html( self::switch_back_message( $old_user ) ),
 					'href' => add_query_arg( array(
 						'redirect_to' => urlencode( self::current_url() ),
 					), self::switch_back_url( $old_user ) ),
@@ -666,19 +636,13 @@ class user_switching {
 		$old_user = self::get_old_user();
 
 		if ( $old_user instanceof WP_User ) {
-			$link = sprintf(
-				/* Translators: 1: user display name; 2: username; */
-				__( 'Switch back to %1$s (%2$s)', 'user-switching' ),
-				$old_user->display_name,
-				$old_user->user_login
-			);
 			$url = add_query_arg( array(
 				'redirect_to' => urlencode( self::current_url() ),
 			), self::switch_back_url( $old_user ) );
 			printf(
 				'<li id="user_switching_switch_on"><a href="%s">%s</a></li>',
 				esc_url( $url ),
-				esc_html( $link )
+				esc_html( self::switch_back_message( $old_user ) )
 			);
 		}
 	}
@@ -707,19 +671,13 @@ class user_switching {
 		$old_user = self::get_old_user();
 
 		if ( $old_user instanceof WP_User ) {
-			$link = sprintf(
-				/* Translators: 1: user display name; 2: username; */
-				__( 'Switch back to %1$s (%2$s)', 'user-switching' ),
-				$old_user->display_name,
-				$old_user->user_login
-			);
 			$url = add_query_arg( array(
 				'redirect_to' => urlencode( self::current_url() ),
 			), self::switch_back_url( $old_user ) );
 			printf(
 				'<p id="user_switching_switch_on"><a href="%s">%s</a></p>',
 				esc_url( $url ),
-				esc_html( $link )
+				esc_html( self::switch_back_message( $old_user ) )
 			);
 		}
 	}
@@ -734,12 +692,6 @@ class user_switching {
 		$old_user = self::get_old_user();
 
 		if ( $old_user instanceof WP_User ) {
-			$link = sprintf(
-				/* Translators: 1: user display name; 2: username; */
-				__( 'Switch back to %1$s (%2$s)', 'user-switching' ),
-				$old_user->display_name,
-				$old_user->user_login
-			);
 			$url = self::switch_back_url( $old_user );
 
 			if ( ! empty( $_REQUEST['interim-login'] ) ) {
@@ -757,7 +709,7 @@ class user_switching {
 			$message .= sprintf(
 				'<a href="%1$s" onclick="window.location.href=\'%1$s\';return false;">%2$s</a>',
 				esc_url( $url ),
-				esc_html( $link )
+				esc_html( self::switch_back_message( $old_user ) )
 			);
 			$message .= '</p>';
 		}
@@ -954,6 +906,69 @@ class user_switching {
 	}
 
 	/**
+	 * Returns the message shown to the user when they've switched to a user.
+	 *
+	 * @param WP_User $user The concerned user.
+	 * @return string The message.
+	 */
+	public static function switched_to_message( WP_User $user ) {
+		$message = sprintf(
+			/* Translators: 1: user display name; 2: username; */
+			__( 'Switched to %1$s (%2$s).', 'user-switching' ),
+			$user->display_name,
+			$user->user_login
+		);
+
+		// Removes the user login from this message without invalidating existing translations
+		return str_replace( sprintf(
+			' (%s)',
+			$user->user_login
+		), '', $message );
+	}
+
+	/**
+	 * Returns the message shown to the user for the link to switch back to their original user.
+	 *
+	 * @param WP_User $user The concerned user.
+	 * @return string The message.
+	 */
+	public static function switch_back_message( WP_User $user ) {
+		$message = sprintf(
+			/* Translators: 1: user display name; 2: username; */
+			__( 'Switch back to %1$s (%2$s)', 'user-switching' ),
+			$user->display_name,
+			$user->user_login
+		);
+
+		// Removes the user login from this message without invalidating existing translations
+		return str_replace( sprintf(
+			' (%s)',
+			$user->user_login
+		), '', $message );
+	}
+
+	/**
+	 * Returns the message shown to the user when they've switched back to their original user.
+	 *
+	 * @param WP_User $user The concerned user.
+	 * @return string The message.
+	 */
+	public static function switched_back_message( WP_User $user ) {
+		$message = sprintf(
+			/* Translators: 1: user display name; 2: username; */
+			__( 'Switched back to %1$s (%2$s).', 'user-switching' ),
+			$user->display_name,
+			$user->user_login
+		);
+
+		// Removes the user login from this message without invalidating existing translations
+		return str_replace( sprintf(
+			' (%s)',
+			$user->user_login
+		), '', $message );
+	}
+
+	/**
 	 * Returns the current URL.
 	 *
 	 * @return string The current URL.
@@ -1047,12 +1062,7 @@ class user_switching {
 			return $items;
 		}
 
-		$items['user-switching-switch-back'] = sprintf(
-			/* Translators: 1: user display name; 2: username; */
-			__( 'Switch back to %1$s (%2$s)', 'user-switching' ),
-			$old_user->display_name,
-			$old_user->user_login
-		);
+		$items['user-switching-switch-back'] = self::switch_back_message( $old_user );
 
 		return $items;
 	}


### PR DESCRIPTION
Not changing the internationalised strings means all the existing translations on wordpress.org don't get invalidated.