### PR TITLE
Add a 'Switch back to {user}' link to access denied messages within the admin area

### DIFF
--- a/tests/acceptance/AccessDeniedCest.php
+++ b/tests/acceptance/AccessDeniedCest.php
@@ -17,6 +17,7 @@ final class AccessDeniedCest {
 		$I->haveUserInDatabase( 'editor', 'editor' );
 		$I->switchToUser( 'editor' );
 		$I->amOnAdminPage( '/tools.php?page=foo' );
+		$I->seeInTitle( 'Error' );
 		$I->switchBackTo( 'admin' );
 		$I->seeCurrentUrlEquals( '/wp-admin/tools.php?page=foo&user_switched=true&switched_back=true' );
 	}

--- a/tests/acceptance/AccessDeniedCest.php
+++ b/tests/acceptance/AccessDeniedCest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace UserSwitching\Tests;
+
+/**
+ * Acceptance tests for "access denied" scenarios.
+ */
+final class AccessDeniedCest {
+	public function _before( \AcceptanceTester $I ): void {
+		$I->comment( 'As a user who has switched accounts' );
+		$I->comment( 'I want to see a Switch Back link on "access denied" screens' );
+		$I->comment( 'In order to quickly switch back to my original account' );
+	}
+
+	public function SwitchBackFromPageAccessDenied( \AcceptanceTester $I ): void {
+		$I->loginAsAdmin();
+		$I->haveUserInDatabase( 'editor', 'editor' );
+		$I->switchToUser( 'editor' );
+		$I->amOnAdminPage( '/tools.php?page=foo' );
+		$I->switchBackTo( 'admin' );
+		$I->seeCurrentUrlEquals( '/wp-admin/tools.php?page=foo&user_switched=true&switched_back=true' );
+	}
+}


### PR DESCRIPTION
Fixes #116

This adds a switch back link to access denied messages within the admin area. This covers:

* Attempting to access the admin area of a site on a multisite network to which you don't have access
* Attempting to access a `?page=<page>` admin screen to which you don't have access

It doesn't cover the more general "You need a higher level of permission" error messages when attempting to access built-in admin screens to which you don't have access. It is possible to add the link to these screens but some additional guard conditions are needed to ensure the message only shows up when appropriate.

## Screenshots

![](https://github.com/johnbillion/user-switching/assets/208434/7ddb3532-80ed-4304-a5b0-eae354111b68)

![](https://github.com/johnbillion/user-switching/assets/208434/2f0393e5-f74c-4690-bae3-7b7357fa1723)
