### PR TITLE
Ask for confirmation when switching into an account which somebody else is already switched into

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -250,6 +250,12 @@ One or more of the above should allow you to correlate an action with the origin
 
 Bear in mind that even without the User Switching plugin in use, any user who has the ability to edit another user can still frame another user for an action by, for example, changing their password and manually logging into that account. If you are concerned about users abusing others, you should take great care when granting users administrative rights.
 
+### Does this plugin warn me if I attempt to switch into an account which somebody else is already switched into?
+
+Yes. When this happens you'll be shown a prompt asking you to confirm that you would like to continue switching to the affected account.
+
+This feature is useful if you have multiple users on your site who may be switching into other user accounts at the same time, for example a team of support agents.
+
 ### Can I switch users directly from the admin toolbar?
 
 Yes, there's a third party add-on plugin for this: [Admin Bar User Switching](https://wordpress.org/plugins/admin-bar-user-switching/).

--- a/tests/integration/ClashTest.php
+++ b/tests/integration/ClashTest.php
@@ -33,14 +33,16 @@ final class ClashTest extends Test {
 		// Switch the first admin to author
 		switch_to_user( self::$users['author']->ID );
 
-		// Set up the second admin user state
-		wp_set_current_user( $admin2->ID );
-		wp_set_auth_cookie( $admin2->ID, false, '', $admin2_token );
-
 		// Verify that the session clash is detected
 		self::assertIsArray( user_switching::detect_session_clash( self::$users['author'] ) );
 
 		// Verify that no session clash is detected for another user
 		self::assertNull( user_switching::detect_session_clash( self::$users['editor'] ) );
+
+		// Switch the first admin back to their admin account
+		switch_to_user( $admin1->ID, false, false );
+
+		// Verify that there is now no session clash
+		self::assertNull( user_switching::detect_session_clash( self::$users['author'] ) );
 	}
 }

--- a/tests/integration/ClashTest.php
+++ b/tests/integration/ClashTest.php
@@ -10,27 +10,20 @@ final class ClashTest extends Test {
 	 * @covers \user_switching::detect_session_clash
 	 */
 	public function testSessionClashIsDetected(): void {
-		$admin1 = self::$testers['admin'];
-		$admin2 = self::factory()->user->create_and_get( array(
-			'role' => 'administrator',
-		) );
+		$admin = self::$testers['admin'];
 
-		// Set up the first admin session manager with a session
-		$admin1_manager = WP_Session_Tokens::get_instance( $admin1->ID );
-		$admin1_token = $admin1_manager->create( time() + DAY_IN_SECONDS );
+		// Set up the admin session manager with a session
+		$admin_manager = WP_Session_Tokens::get_instance( $admin->ID );
+		$admin_token = $admin_manager->create( time() + DAY_IN_SECONDS );
 
-		// Set up the second admin session manager with a session
-		$admin2_manager = WP_Session_Tokens::get_instance( $admin2->ID );
-		$admin2_token = $admin2_manager->create( time() + DAY_IN_SECONDS );
-
-		// Set up the first admin user state
-		wp_set_current_user( $admin1->ID );
-		wp_set_auth_cookie( $admin1->ID, false, '', $admin1_token );
+		// Set up the admin user state
+		wp_set_current_user( $admin->ID );
+		wp_set_auth_cookie( $admin->ID, false, '', $admin_token );
 
 		// Verify that there is no session clash
 		self::assertNull( user_switching::detect_session_clash( self::$users['author'] ) );
 
-		// Switch the first admin to author
+		// Switch the admin to author
 		switch_to_user( self::$users['author']->ID );
 
 		// Verify that the session clash is detected
@@ -39,8 +32,8 @@ final class ClashTest extends Test {
 		// Verify that no session clash is detected for another user
 		self::assertNull( user_switching::detect_session_clash( self::$users['editor'] ) );
 
-		// Switch the first admin back to their admin account
-		switch_to_user( $admin1->ID, false, false );
+		// Switch the admin back to their admin account
+		switch_to_user( $admin->ID, false, false );
 
 		// Verify that there is now no session clash
 		self::assertNull( user_switching::detect_session_clash( self::$users['author'] ) );

--- a/tests/integration/ClashTest.php
+++ b/tests/integration/ClashTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace UserSwitching\Tests;
+
+use user_switching;
+use WP_Session_Tokens;
+
+final class ClashTest extends Test {
+	/**
+	 * @covers \user_switching::detect_session_clash
+	 */
+	public function testSessionClashIsDetected(): void {
+		$admin1 = self::$testers['admin'];
+		$admin2 = self::factory()->user->create_and_get( array(
+			'role' => 'administrator',
+		) );
+
+		// Set up the first admin session manager with a session
+		$admin1_manager = WP_Session_Tokens::get_instance( $admin1->ID );
+		$admin1_token = $admin1_manager->create( time() + DAY_IN_SECONDS );
+
+		// Set up the second admin session manager with a session
+		$admin2_manager = WP_Session_Tokens::get_instance( $admin2->ID );
+		$admin2_token = $admin2_manager->create( time() + DAY_IN_SECONDS );
+
+		// Verify that there is no session clash
+		self::assertNull( user_switching::detect_session_clash( self::$users['author'] ) );
+
+		// Set up the first admin user state
+		wp_set_current_user( $admin1->ID );
+		wp_set_auth_cookie( $admin1->ID, false, '', $admin1_token );
+
+		// Switch the first admin to author
+		switch_to_user( self::$users['author']->ID );
+
+		// Set up the second admin user state
+		wp_set_current_user( $admin2->ID );
+		wp_set_auth_cookie( $admin2->ID, false, '', $admin2_token );
+
+		// Verify that the session clash is detected
+		self::assertIsArray( user_switching::detect_session_clash( self::$users['author'] ) );
+	}
+}

--- a/tests/integration/ClashTest.php
+++ b/tests/integration/ClashTest.php
@@ -23,12 +23,12 @@ final class ClashTest extends Test {
 		$admin2_manager = WP_Session_Tokens::get_instance( $admin2->ID );
 		$admin2_token = $admin2_manager->create( time() + DAY_IN_SECONDS );
 
-		// Verify that there is no session clash
-		self::assertNull( user_switching::detect_session_clash( self::$users['author'] ) );
-
 		// Set up the first admin user state
 		wp_set_current_user( $admin1->ID );
 		wp_set_auth_cookie( $admin1->ID, false, '', $admin1_token );
+
+		// Verify that there is no session clash
+		self::assertNull( user_switching::detect_session_clash( self::$users['author'] ) );
 
 		// Switch the first admin to author
 		switch_to_user( self::$users['author']->ID );

--- a/tests/integration/ClashTest.php
+++ b/tests/integration/ClashTest.php
@@ -39,5 +39,8 @@ final class ClashTest extends Test {
 
 		// Verify that the session clash is detected
 		self::assertIsArray( user_switching::detect_session_clash( self::$users['author'] ) );
+
+		// Verify that no session clash is detected for another user
+		self::assertNull( user_switching::detect_session_clash( self::$users['editor'] ) );
 	}
 }

--- a/user-switching.php
+++ b/user-switching.php
@@ -209,7 +209,7 @@ class user_switching {
 						// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 						do_action( 'qm/cease' );
 
-						$sentence = sprintf(
+						$message = sprintf(
 							/* Translators: 1: The name of the user who is currently switched to the target user, 2: The name of the target user, 3: Period of time (for example "5 minutes") */
 							__( '%1$s is currently switched to %2$s. They switched %3$s ago. Do you want to continue switching?', 'user-switching' ),
 							$clash['user']->display_name,
@@ -221,17 +221,17 @@ class user_switching {
 							__( 'Yes, switch to %s', 'user-switching' ),
 							$target->display_name,
 						);
-						$message = sprintf(
-							'%1$s<br><br><a class="button" href="%2$s">%3$s</a> &nbsp; <a class="button" href="%4$s">%5$s</a>',
-							esc_html( $sentence ),
-							esc_url( add_query_arg( 'force_switch_user', '1' ) ),
-							esc_html( $yes ),
-							'javascript:history.back()',
-							esc_html__( 'No, go back', 'user-switching' ),
-						);
+						$no = __( 'No, go back', 'user-switching' );
 
 						wp_die(
-							$message,
+							sprintf(
+								'%1$s<br><br><a class="button" href="%2$s">%3$s</a> &nbsp; <a class="button" href="%4$s">%5$s</a>',
+								esc_html( $message ),
+								esc_url( add_query_arg( 'force_switch_user', '1' ) ),
+								esc_html( $yes ),
+								'javascript:history.back()',
+								esc_html( $no ),
+							),
 							'',
 							[
 								'response' => 409,

--- a/user-switching.php
+++ b/user-switching.php
@@ -214,7 +214,7 @@ class user_switching {
 							__( '%1$s is currently switched to %2$s. They switched %3$s ago. Do you want to continue switching?', 'user-switching' ),
 							$clash['user']->display_name,
 							$target->display_name,
-							human_time_diff( $clash['session']['login'] ),
+							human_time_diff( $clash['login'] ),
 						);
 						$yes = sprintf(
 							/* Translators: %s is the name of the target user */
@@ -345,13 +345,7 @@ class user_switching {
 	 * @param WP_User $target Target user.
 	 * @return array|null
 	 * @phpstan-return array{
-	 *   session: array{
-	 *     switched_from_id: int,
-	 *     expiration: int,
-	 *     ip: string,
-	 *     ua: string,
-	 *     login: int,
-	 *   },
+	 *   login: int,
 	 *   user: WP_User,
 	 * }|null
 	 */
@@ -379,7 +373,7 @@ class user_switching {
 		}
 
 		return [
-			'session' => $session,
+			'login' => $session['login'],
 			'user' => $switched_from_user,
 		];
 	}


### PR DESCRIPTION
Fixes #94

## Concerns

* If a user switches into an account and then goes on holiday for a week, other users who attempt to switch into the account will see this message every time they attempt to switch. Annoying, although not the end of the world. Perhaps check the session start time and only show the warning if the switch happened within something like the last 12 hours.
* This doesn't fully support stacked switching. I think that's too much of an edge case for this first version. (I'm questioning how useful stacked switching is, perhaps it needs to go).

## Screenshots

![2024-07-30-22-08-10](https://github.com/user-attachments/assets/da31d728-ad6c-4bb8-92b1-1ae9e3911a7e)
