### PR TITLE
Fix the `wp_login` and `wp_logout` parameter usage

### DIFF
--- a/tests/integration/Test.php
+++ b/tests/integration/Test.php
@@ -62,6 +62,9 @@ abstract class Test extends \Codeception\TestCase\WPTestCase {
 		add_action( 'set_user_switching_cookie', array( $this, 'action_set_user_switching_cookie' ), 10 );
 		add_action( 'set_olduser_cookie',        array( $this, 'action_set_olduser_cookie' ), 10 );
 		add_action( 'clear_olduser_cookie',      array( $this, 'action_clear_olduser_cookie' ) );
+
+		$_COOKIE = [];
+		$this->sessions = [];
 	}
 
 	final public function action_set_auth_cookie(

--- a/user-switching.php
+++ b/user-switching.php
@@ -65,8 +65,8 @@ final class user_switching {
 		add_action( 'plugins_loaded', [ $this, 'action_plugins_loaded' ], 1 );
 		add_action( 'init', [ $this, 'action_init' ] );
 		add_action( 'all_admin_notices', [ $this, 'action_admin_notices' ], 1 );
-		add_action( 'wp_logout', 'user_switching_clear_olduser_cookie' );
-		add_action( 'wp_login', 'user_switching_clear_olduser_cookie' );
+		add_action( 'wp_logout', 'user_switching_clear_olduser_cookie', 10, 0 );
+		add_action( 'wp_login', 'user_switching_clear_olduser_cookie', 10, 0 );
 
 		// Nice-to-haves:
 		add_filter( 'ms_user_row_actions', [ $this, 'filter_user_row_actions' ], 10, 2 );


### PR DESCRIPTION
Fixes #142 