### PR TITLE
Guard against undefined cookie constant in wp_die handler

### DIFF
--- a/user-switching.php
+++ b/user-switching.php
@@ -668,6 +668,10 @@ final class user_switching {
 			return;
 		}
 
+		if ( ! defined( 'USER_SWITCHING_OLDUSER_COOKIE' ) ) {
+			return;
+		}
+
 		$old_user = self::get_old_user();
 
 		if ( ! ( $old_user instanceof WP_User ) ) {

--- a/user-switching.php
+++ b/user-switching.php
@@ -683,7 +683,7 @@ final class user_switching {
 			return;
 		}
 
-		if ( ! did_action( 'plugins_loaded' ) ) {
+		if ( ! defined( 'USER_SWITCHING_OLDUSER_COOKIE' ) ) {
 			return;
 		}
 

--- a/user-switching.php
+++ b/user-switching.php
@@ -668,7 +668,7 @@ final class user_switching {
 			return;
 		}
 
-		if ( ! defined( 'USER_SWITCHING_OLDUSER_COOKIE' ) ) {
+		if ( ! did_action( 'plugins_loaded' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
When wp_die() is called before the plugins_loaded hook fires, the
USER_SWITCHING_OLDUSER_COOKIE constant has not yet been defined, which
causes a PHP warning. Add an early return in action_shutdown_for_wp_die()
if the constant is not defined.

https://claude.ai/code/session_019Q2an15FJNgkW7TAvN47yF