### PR TITLE
Fix expired nonce on switch back link after concurrent session logout

### DIFF
--- a/tests/acceptance/ExpiredNonce.spec.ts
+++ b/tests/acceptance/ExpiredNonce.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from './utils/test-setup';
+
+test.describe( 'Expired Nonce', () => {
+	test.beforeAll( async ( { globalUtils } ) => {
+		globalUtils.installWordPress();
+		globalUtils.runWPCLICommand( 'user create admin2 admin2@example.com --role=administrator --display_name="admin2" --user_pass=password' );
+		globalUtils.runWPCLICommand( 'user create subscriber subscriber@example.com --role=subscriber --display_name="subscriber" --user_pass=password' );
+	} );
+
+	test( 'Switch back link works after another user logs out everywhere else', {
+		annotation: {
+			type: 'issue',
+			description: 'https://github.com/johnbillion/user-switching/issues/144'
+		}
+	}, async ( {
+		page,
+		browser,
+		admin,
+		userSwitching,
+	} ) => {
+		// User A: Login as admin and switch to subscriber
+		await userSwitching.loginViaPage( 'admin', 'password' );
+		await userSwitching.switchToUser( 'subscriber' );
+		await userSwitching.verifyLoggedInAs( 'subscriber' );
+
+		// User B: Create a separate browser context with independent cookies
+		const contextB = await browser.newContext();
+		const pageB = await contextB.newPage();
+
+		// User B: Login as admin2
+		await pageB.goto( '/wp-login.php' );
+		await pageB.fill( 'input[name="log"]', 'admin2' );
+		await pageB.fill( 'input[name="pwd"]', 'password' );
+		await pageB.locator( '#wp-submit' ).click();
+		await expect( pageB.locator( '#wpadminbar .display-name' ).first() ).toContainText( 'admin2' );
+
+		// User B: Switch to subscriber (with force, as admin is already switched)
+		const subscriberId = await pageB.evaluate( async () => {
+			const response = await fetch( '/wp-json/wp/v2/users?search=subscriber', {
+				headers: { 'X-WP-Nonce': ( window as any ).wpApiSettings?.nonce || '' },
+			} );
+			const users = await response.json();
+			return users[0]?.id;
+		} );
+
+		// Navigate to user edit page and click Switch To
+		await pageB.goto( `/wp-admin/user-edit.php?user_id=${subscriberId}` );
+		// Handle the duplicate switch confirmation if it appears
+		const [response] = await Promise.all( [
+			pageB.waitForNavigation(),
+			pageB.locator( '#user_switching_switcher' ).click(),
+		] );
+
+		// If we got a duplicate switch warning (409), click "Yes, switch"
+		if ( pageB.url().includes( 'action=switch_to_user' ) ) {
+			const yesButton = pageB.locator( 'a.button', { hasText: /Yes, switch/ } );
+			if ( await yesButton.isVisible( { timeout: 2000 } ).catch( () => false ) ) {
+				await yesButton.click();
+			}
+		}
+
+		// Verify User B is now subscriber
+		await pageB.goto( '/wp-admin/' );
+		await expect( pageB.locator( '#wpadminbar .display-name' ).first() ).toContainText( 'subscriber' );
+
+		// User A: Click "Log Out Everywhere Else" on subscriber's profile
+		await admin.visitAdminPage( 'profile.php' );
+		await page.locator( 'button:has-text("Log Out Everywhere Else")' ).click();
+		await expect( page.locator( '[role="alert"]' ) ).toContainText( 'You are now logged out everywhere else.' );
+
+		// User B: Their session is now destroyed. Try to access wp-admin.
+		await pageB.goto( '/wp-admin/' );
+
+		// User B should be redirected to login page
+		expect( pageB.url() ).toContain( 'wp-login.php' );
+
+		// User B should see a "Switch back to admin2" link on the login page
+		const switchBackLink = pageB.locator( '#user_switching_switch_on a' );
+		await expect( switchBackLink ).toContainText( 'Switch back to admin2' );
+
+		// User B: Click the switch back link - this is the critical action
+		// Before the fix, this would show "The link you followed has expired"
+		await switchBackLink.click();
+
+		// Verify User B successfully switched back to admin2
+		expect( pageB.url() ).toContain( 'user_switched=true' );
+		expect( pageB.url() ).toContain( 'switched_back=true' );
+		await expect( pageB.locator( '#wpadminbar .display-name' ).first() ).toContainText( 'admin2' );
+
+		// Clean up
+		await contextB.close();
+	} );
+} );

--- a/tests/acceptance/ExpiredNonce.spec.ts
+++ b/tests/acceptance/ExpiredNonce.spec.ts
@@ -3,91 +3,41 @@ import { test, expect } from './utils/test-setup';
 test.describe( 'Expired Nonce', () => {
 	test.beforeAll( async ( { globalUtils } ) => {
 		globalUtils.installWordPress();
-		globalUtils.runWPCLICommand( 'user create admin2 admin2@example.com --role=administrator --display_name="admin2" --user_pass=password' );
 		globalUtils.runWPCLICommand( 'user create subscriber subscriber@example.com --role=subscriber --display_name="subscriber" --user_pass=password' );
 	} );
 
-	test( 'Switch back link works after another user logs out everywhere else', {
+	test( 'Switch back link works after session is destroyed', {
 		annotation: {
 			type: 'issue',
 			description: 'https://github.com/johnbillion/user-switching/issues/144'
 		}
 	}, async ( {
 		page,
-		browser,
-		admin,
+		globalUtils,
 		userSwitching,
 	} ) => {
-		// User A: Login as admin and switch to subscriber
+		// Login as admin and switch to subscriber
 		await userSwitching.loginViaPage( 'admin', 'password' );
 		await userSwitching.switchToUser( 'subscriber' );
 		await userSwitching.verifyLoggedInAs( 'subscriber' );
 
-		// User B: Create a separate browser context with independent cookies
-		const contextB = await browser.newContext();
-		const pageB = await contextB.newPage();
+		// Destroy all subscriber sessions via WP-CLI
+		globalUtils.runWPCLICommand( 'user session destroy subscriber --all' );
 
-		// User B: Login as admin2
-		await pageB.goto( '/wp-login.php' );
-		await pageB.fill( 'input[name="log"]', 'admin2' );
-		await pageB.fill( 'input[name="pwd"]', 'password' );
-		await pageB.locator( '#wp-submit' ).click();
-		await expect( pageB.locator( '#wpadminbar .display-name' ).first() ).toContainText( 'admin2' );
+		// Try to access wp-admin, which redirects to login with stale cookie
+		await page.goto( '/wp-admin/' );
+		expect( page.url() ).toContain( 'wp-login.php' );
 
-		// User B: Switch to subscriber (with force, as admin is already switched)
-		const subscriberId = await pageB.evaluate( async () => {
-			const response = await fetch( '/wp-json/wp/v2/users?search=subscriber', {
-				headers: { 'X-WP-Nonce': ( window as any ).wpApiSettings?.nonce || '' },
-			} );
-			const users = await response.json();
-			return users[0]?.id;
-		} );
+		// The switch back link should be present on the login page
+		const switchBackLink = page.locator( '#user_switching_switch_on a' );
+		await expect( switchBackLink ).toContainText( 'Switch back to admin' );
 
-		// Navigate to user edit page and click Switch To
-		await pageB.goto( `/wp-admin/user-edit.php?user_id=${subscriberId}` );
-		// Handle the duplicate switch confirmation if it appears
-		const [response] = await Promise.all( [
-			pageB.waitForNavigation(),
-			pageB.locator( '#user_switching_switcher' ).click(),
-		] );
-
-		// If we got a duplicate switch warning (409), click "Yes, switch"
-		if ( pageB.url().includes( 'action=switch_to_user' ) ) {
-			const yesButton = pageB.locator( 'a.button', { hasText: /Yes, switch/ } );
-			if ( await yesButton.isVisible( { timeout: 2000 } ).catch( () => false ) ) {
-				await yesButton.click();
-			}
-		}
-
-		// Verify User B is now subscriber
-		await pageB.goto( '/wp-admin/' );
-		await expect( pageB.locator( '#wpadminbar .display-name' ).first() ).toContainText( 'subscriber' );
-
-		// User A: Click "Log Out Everywhere Else" on subscriber's profile
-		await admin.visitAdminPage( 'profile.php' );
-		await page.locator( 'button:has-text("Log Out Everywhere Else")' ).click();
-		await expect( page.locator( '[role="alert"]' ) ).toContainText( 'You are now logged out everywhere else.' );
-
-		// User B: Their session is now destroyed. Try to access wp-admin.
-		await pageB.goto( '/wp-admin/' );
-
-		// User B should be redirected to login page
-		expect( pageB.url() ).toContain( 'wp-login.php' );
-
-		// User B should see a "Switch back to admin2" link on the login page
-		const switchBackLink = pageB.locator( '#user_switching_switch_on a' );
-		await expect( switchBackLink ).toContainText( 'Switch back to admin2' );
-
-		// User B: Click the switch back link - this is the critical action
-		// Before the fix, this would show "The link you followed has expired"
+		// Click the switch back link - before the fix this showed "The link you followed has expired"
 		await switchBackLink.click();
 
-		// Verify User B successfully switched back to admin2
-		expect( pageB.url() ).toContain( 'user_switched=true' );
-		expect( pageB.url() ).toContain( 'switched_back=true' );
-		await expect( pageB.locator( '#wpadminbar .display-name' ).first() ).toContainText( 'admin2' );
-
-		// Clean up
-		await contextB.close();
+		// Verify successfully switched back to admin
+		expect( page.url() ).toContain( 'user_switched=true' );
+		expect( page.url() ).toContain( 'switched_back=true' );
+		await expect( page.locator( '#wpadminbar .display-name' ).first() ).toContainText( 'admin' );
 	} );
 } );

--- a/user-switching.php
+++ b/user-switching.php
@@ -68,6 +68,7 @@ final class user_switching {
 		add_action( 'all_admin_notices', [ $this, 'action_admin_notices' ], 1 );
 		add_action( 'wp_logout', 'user_switching_clear_olduser_cookie', 10, 0 );
 		add_action( 'wp_login', 'user_switching_clear_olduser_cookie', 10, 0 );
+		add_action( 'clear_auth_cookie', [ $this, 'action_clear_auth_cookie' ] );
 
 		// Nice-to-haves:
 		add_filter( 'ms_user_row_actions', [ $this, 'filter_user_row_actions' ], 10, 2 );
@@ -114,6 +115,20 @@ final class user_switching {
 		if ( ! defined( 'USER_SWITCHING_OLDUSER_COOKIE' ) ) {
 			define( 'USER_SWITCHING_OLDUSER_COOKIE', 'wordpress_user_sw_olduser_' . COOKIEHASH );
 		}
+	}
+
+	/**
+	 * Clears the stale logged-in cookie from the superglobal when auth cookies are being cleared.
+	 *
+	 * WordPress's `wp_clear_auth_cookie()` sends `Set-Cookie` headers to clear the browser cookies
+	 * but does not update `$_COOKIE`, so code running later in the same request still sees the stale
+	 * value. This causes `wp_get_session_token()` to return a dead session token, which in turn
+	 * causes `wp_create_nonce()` to generate a nonce that will fail verification on the next request.
+	 *
+	 * @link https://github.com/johnbillion/user-switching/issues/144
+	 */
+	public function action_clear_auth_cookie(): void {
+		unset( $_COOKIE[ LOGGED_IN_COOKIE ] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #144

When two users switch into the same account and one clicks "Log Out Everywhere Else", the other user's "Switch back" link on the login page shows "The link you followed has expired".

The root cause is in WordPress core: `wp-login.php` calls `wp_clear_auth_cookie()` on the `reauth` path which sends `Set-Cookie` headers to clear the browser cookies, but leaves `$_COOKIE` stale for the rest of the request. When `wp_create_nonce()` runs later, `wp_get_session_token()` reads the dead session token from `$_COOKIE`, producing a nonce that will fail verification on the next request when the browser no longer sends the cookie.
