### PR TITLE
Release the post lock when switching back from the post editing screen

### DIFF
--- a/tests/acceptance/PostLock.spec.ts
+++ b/tests/acceptance/PostLock.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from './utils/test-setup';
+
+test.describe( 'Post Lock', () => {
+	let sharedPostId: string;
+	let editorId: string;
+
+	test.beforeAll( async ( { globalUtils } ) => {
+		await globalUtils.installWordPress();
+		sharedPostId = globalUtils.runWPCLICommand( 'post create --post_title="Test Post" --post_status=publish --porcelain' );
+		editorId = globalUtils.runWPCLICommand( 'user create editor editor@example.com --role=editor --user_pass=password --porcelain' );
+	} );
+
+	test( 'Switch back from a post editing screen releases the post lock', {
+		annotation: {
+			type: 'user-story',
+			description: 'As a user who has switched accounts to edit a post, I want to switch back without seeing the post locked modal, in order to continue editing'
+		}
+	}, async ( {
+		page,
+		admin,
+		userSwitching,
+		globalUtils,
+	} ) => {
+		await userSwitching.loginViaPage( 'admin', 'password' );
+
+		// Simulate a fresh lock left behind by the editor user.
+		const setStaleLock = () => {
+			const now = Math.floor( Date.now() / 1000 );
+			globalUtils.runWPCLICommand( `post meta update ${sharedPostId} _edit_lock "${now}:${editorId}"` );
+		};
+
+		// Without the after-switch-back query args, the lock modal should be visible.
+		setStaleLock();
+		await admin.visitAdminPage( 'post.php', `post=${sharedPostId}&action=edit` );
+		await expect( page.getByText( 'This post is already being edited' ) ).toBeVisible();
+
+		// With the after-switch-back query args, the lock modal should not be visible.
+		setStaleLock();
+		await admin.visitAdminPage( 'post.php', `post=${sharedPostId}&action=edit&user_switched=true&switched_back=true` );
+		await expect( page.getByText( 'This post is already being edited' ) ).not.toBeVisible();
+	} );
+} );

--- a/tests/integration/PostLockTest.php
+++ b/tests/integration/PostLockTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace UserSwitching\Tests;
+
+/**
+ * @covers \user_switching::filter_post_lock_window_after_switch
+ */
+final class PostLockTest extends Test {
+	public function testPostLockWindowIsZeroedOnPostEditScreenAfterSwitch(): void {
+		$_GET = [
+			'user_switched' => 'true',
+			'action' => 'edit',
+		];
+
+		self::assertSame( 0, apply_filters( 'wp_check_post_lock_window', 150 ) );
+	}
+
+	public function testPostLockWindowIsUnchangedWithoutUserSwitched(): void {
+		$_GET = [
+			'action' => 'edit',
+		];
+
+		self::assertSame( 150, apply_filters( 'wp_check_post_lock_window', 150 ) );
+	}
+
+	public function testPostLockWindowIsUnchangedWhenActionIsNotEdit(): void {
+		$_GET = [
+			'user_switched' => 'true',
+		];
+
+		self::assertSame( 150, apply_filters( 'wp_check_post_lock_window', 150 ) );
+	}
+
+	public function testStalePostLockIsTreatedAsExpiredAfterSwitch(): void {
+		$current = self::$testers['admin'];
+		$previous = self::$users['editor'];
+
+		$post = self::factory()->post->create_and_get();
+		self::assertInstanceOf( 'WP_Post', $post );
+
+		wp_set_current_user( $current->ID );
+
+		// Simulate a fresh lock left behind by the user being switched away from.
+		update_post_meta( $post->ID, '_edit_lock', time() . ':' . $previous->ID );
+
+		// Without the after-switch query args, the lock is considered active.
+		$_GET = [];
+		self::assertSame( $previous->ID, wp_check_post_lock( $post->ID ) );
+
+		// With the after-switch query args, the lock is treated as expired.
+		$_GET = [
+			'user_switched' => 'true',
+			'action' => 'edit',
+		];
+		self::assertFalse( wp_check_post_lock( $post->ID ) );
+	}
+}

--- a/tests/integration/PostLockTest.php
+++ b/tests/integration/PostLockTest.php
@@ -3,19 +3,19 @@
 namespace UserSwitching\Tests;
 
 /**
- * @covers \user_switching::filter_post_lock_window_after_switch
+ * @covers \user_switching::filter_post_lock_window_after_switch_back
  */
 final class PostLockTest extends Test {
-	public function testPostLockWindowIsZeroedOnPostEditScreenAfterSwitch(): void {
+	public function testPostLockWindowIsZeroedOnPostEditScreenAfterSwitchBack(): void {
 		$_GET = [
-			'user_switched' => 'true',
+			'switched_back' => 'true',
 			'action' => 'edit',
 		];
 
 		self::assertSame( 0, apply_filters( 'wp_check_post_lock_window', 150 ) );
 	}
 
-	public function testPostLockWindowIsUnchangedWithoutUserSwitched(): void {
+	public function testPostLockWindowIsUnchangedWithoutSwitchedBack(): void {
 		$_GET = [
 			'action' => 'edit',
 		];
@@ -25,13 +25,13 @@ final class PostLockTest extends Test {
 
 	public function testPostLockWindowIsUnchangedWhenActionIsNotEdit(): void {
 		$_GET = [
-			'user_switched' => 'true',
+			'switched_back' => 'true',
 		];
 
 		self::assertSame( 150, apply_filters( 'wp_check_post_lock_window', 150 ) );
 	}
 
-	public function testStalePostLockIsTreatedAsExpiredAfterSwitch(): void {
+	public function testStalePostLockIsTreatedAsExpiredAfterSwitchBack(): void {
 		$current = self::$testers['admin'];
 		$previous = self::$users['editor'];
 
@@ -43,13 +43,13 @@ final class PostLockTest extends Test {
 		// Simulate a fresh lock left behind by the user being switched away from.
 		update_post_meta( $post->ID, '_edit_lock', time() . ':' . $previous->ID );
 
-		// Without the after-switch query args, the lock is considered active.
+		// Without the after-switch-back query args, the lock is considered active.
 		$_GET = [];
 		self::assertSame( $previous->ID, wp_check_post_lock( $post->ID ) );
 
-		// With the after-switch query args, the lock is treated as expired.
+		// With the after-switch-back query args, the lock is treated as expired.
 		$_GET = [
-			'user_switched' => 'true',
+			'switched_back' => 'true',
 			'action' => 'edit',
 		];
 		self::assertFalse( wp_check_post_lock( $post->ID ) );

--- a/user-switching.php
+++ b/user-switching.php
@@ -73,6 +73,7 @@ final class user_switching {
 		add_filter( 'ms_user_row_actions', [ $this, 'filter_user_row_actions' ], 10, 2 );
 		add_filter( 'login_message', [ $this, 'filter_login_message' ], 1 );
 		add_filter( 'removable_query_args', [ $this, 'filter_removable_query_args' ] );
+		add_filter( 'wp_check_post_lock_window', [ $this, 'filter_post_lock_window_after_switch' ] );
 		add_action( 'wp_meta', [ $this, 'action_wp_meta' ] );
 		add_filter( 'plugin_row_meta', [ $this, 'filter_plugin_row_meta' ], 10, 2 );
 		add_action( 'wp_footer', [ $this, 'action_wp_footer' ] );
@@ -973,6 +974,24 @@ final class user_switching {
 			'switched_off',
 			'switched_back',
 		] );
+	}
+
+	/**
+	 * Treats the post lock as expired on the post-edit screen immediately after a user switch.
+	 *
+	 * @param  int $window The post lock window duration in seconds.
+	 * @return int The filtered post lock window duration in seconds.
+	 */
+	public function filter_post_lock_window_after_switch( int $window ): int {
+		if ( empty( $_GET['user_switched'] ) ) {
+			return $window;
+		}
+
+		if ( ( $_GET['action'] ?? '' ) !== 'edit' ) {
+			return $window;
+		}
+
+		return 0;
 	}
 
 	/**

--- a/user-switching.php
+++ b/user-switching.php
@@ -73,7 +73,7 @@ final class user_switching {
 		add_filter( 'ms_user_row_actions', [ $this, 'filter_user_row_actions' ], 10, 2 );
 		add_filter( 'login_message', [ $this, 'filter_login_message' ], 1 );
 		add_filter( 'removable_query_args', [ $this, 'filter_removable_query_args' ] );
-		add_filter( 'wp_check_post_lock_window', [ $this, 'filter_post_lock_window_after_switch' ] );
+		add_filter( 'wp_check_post_lock_window', [ $this, 'filter_post_lock_window_after_switch_back' ] );
 		add_action( 'wp_meta', [ $this, 'action_wp_meta' ] );
 		add_filter( 'plugin_row_meta', [ $this, 'filter_plugin_row_meta' ], 10, 2 );
 		add_action( 'wp_footer', [ $this, 'action_wp_footer' ] );
@@ -977,13 +977,13 @@ final class user_switching {
 	}
 
 	/**
-	 * Treats the post lock as expired on the post-edit screen immediately after a user switch.
+	 * Treats the post lock as expired on the post-edit screen immediately after switching back.
 	 *
 	 * @param  int $window The post lock window duration in seconds.
 	 * @return int The filtered post lock window duration in seconds.
 	 */
-	public function filter_post_lock_window_after_switch( int $window ): int {
-		if ( empty( $_GET['user_switched'] ) ) {
+	public function filter_post_lock_window_after_switch_back( int $window ): int {
+		if ( empty( $_GET['switched_back'] ) ) {
 			return $window;
 		}
 


### PR DESCRIPTION
Closes #64.

Releases the post lock after switching back from a post editing screen, preventing the "This post is already being edited" modal from appearing.

Implemented via the `wp_check_post_lock_window` filter.

Developed with AI assistance (Claude).