### PR TITLE
Remove the hardcoded period after the switch-back link

### DIFF
--- a/user-switching.php
+++ b/user-switching.php
@@ -520,7 +520,7 @@ final class user_switching {
 				], self::switch_back_url( $old_user ) );
 
 				$message .= sprintf(
-					' <a href="%s">%s</a>.',
+					' <a href="%s">%s</a>',
 					esc_url( $switch_back_url ),
 					esc_html( self::switch_back_message( $old_user ) )
 				);


### PR DESCRIPTION
Removes the hardcoded period after the switch-back link in the admin notice, as agreed in #279.

The period was output as a literal ASCII `.` after the link, outside any translatable string, so it couldn't be localised for languages that use different sentence punctuation. The switch-back message itself carries no trailing punctuation.

AI assistance disclosure: this change was prepared with the help of an AI coding agent (Claude) and reviewed before submitting.

Fixes #279
