### PR TITLE
Command Palette: Fix useSelect warning

### DIFF
--- a/js/command-palette.js
+++ b/js/command-palette.js
@@ -81,9 +81,9 @@
 					.trim();
 				const search = useDebouncedValue( trimmedSearch );
 
-				const { users, isLoading } = useSelect( function ( select ) {
+				const { users = [], isLoading } = useSelect( function ( select ) {
 					if ( ! search ) {
-						return { users: [], isLoading: false };
+						return { users: undefined, isLoading: false };
 					}
 
 					const query = {
@@ -94,7 +94,7 @@
 					const core = select( coreStore );
 
 					return {
-						users: core.getEntityRecords( 'root', 'user', query ) || [],
+						users: core.getEntityRecords( 'root', 'user', query ) || undefined,
 						isLoading: ! core.hasFinishedResolution( 'getEntityRecords', [ 'root', 'user', query ] ),
 					};
 				}, [ search ] );


### PR DESCRIPTION
## Summary

A minor code quality fix for the `useSelect` hook in the Command Palette. PR fixes a warning triggered by using empty `[ ]`, which will have a new reference every time it's returned, potentially causing unwanted re-renders.

Probably has no actual bad effect in this case, just something I noticed while using this awesome plugin in my development environment.

More about the warning - https://make.wordpress.org/core/2025/03/12/data-a-helpful-performance-warning-for-developers-in-the-useselect-hook/.

## Testing

- [x] I have tested this change on a real installation of WordPress (required)

Steps to test:

1. Enable `WP_DEBUG` and `SCRIPT_DEBUG`.
2. Open a the command paletter - <kbd>CMD</kbd>+<kbd>K</kbd>
3. Notice that on the develop branch, `useSelect` triggers a dev warning.
4. The warning is fixed on this branch, and the user searching works as before.

## AI assistance

None.

## Screenshots

- [x] I have included a before and after screenshot (required, unless there is genuinely no visual change)

### Before

<img width="943" height="380" alt="CleanShot 2026-07-10 at 10 45 49" src="https://github.com/user-attachments/assets/386cbbcb-da3b-4624-94d3-3113be7f9638" />


### After

There's no warning in the DevTools console.

